### PR TITLE
Initialize Optional fields and fix getMechanismY logic

### DIFF
--- a/src/main/java/yams/mechanisms/config/MechanismPositionConfig.java
+++ b/src/main/java/yams/mechanisms/config/MechanismPositionConfig.java
@@ -16,15 +16,15 @@ public class MechanismPositionConfig
   /**
    * The translation from the robot to the mechanism (Optional)
    */
-  protected Optional<Translation3d> robotToMechanism;
+  protected Optional<Translation3d> robotToMechanism = Optional.empty();
   /**
    * The length of the robot in meters.
    */
-  protected Optional<Distance>      maxRobotLength;
+  protected Optional<Distance>      maxRobotLength = Optional.empty();
   /**
    * The height of the robot in meters.
    */
-  protected Optional<Distance>      maxRobotHeight;
+  protected Optional<Distance>      maxRobotHeight = Optional.empty();
   // TODO: Add soft limits display config.
   // TODO: Add hard limits display config.
   /**
@@ -98,14 +98,14 @@ public class MechanismPositionConfig
   }
 
   /**
-   * Converts a given distance in the y-direction to a y-coordinate appropriate for visualizing on a Mechanism2d.
+   * Gets the distance in the y-direction appropriate for visualizing on a Mechanism2d, defaults to the given distance.
    *
-   * @param y the distance in the y-direction
+   * @param y the default distance in the y-direction
    * @return the y-coordinate for visualizing on a Mechanism2d
    */
   public Distance getMechanismY(Distance y)
   {
-    return robotToMechanism.get().getMeasureZ();
+    return robotToMechanism.map(it -> it.getMeasureZ()).orElse(y);
   }
 
   /**


### PR DESCRIPTION
Sets default values for Optional fields to Optional.empty() and updates getMechanismY to safely handle absent robotToMechanism by returning the input value.