### PR TITLE
Add Shooter 'speedometer' simulation style and get SysId working

### DIFF
--- a/examples/simple_shooter/src/main/java/frc/robot/RobotContainer.java
+++ b/examples/simple_shooter/src/main/java/frc/robot/RobotContainer.java
@@ -5,13 +5,12 @@
 
 package frc.robot;
 
+import static edu.wpi.first.units.Units.RPM;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import frc.robot.subsystems.ShooterSubsystem;
-
-import static edu.wpi.first.units.Units.Meters;
 
 
 public class RobotContainer
@@ -29,7 +28,7 @@ public class RobotContainer
 
   private void configureBindings()
   {
-    xboxController.button(1).whileTrue(shooter.setVelocity(RPM.of(60)));
+    xboxController.button(1).whileTrue(shooter.setVelocity(RPM.of(300)));
     xboxController.button(2).whileTrue(shooter.setVelocity(RPM.of(0)));
     xboxController.button(3).whileTrue(shooter.sysId());
     xboxController.button(4).whileTrue(shooter.setDutyCycle(-0.5));

--- a/examples/simple_shooter/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
+++ b/examples/simple_shooter/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
@@ -7,18 +7,28 @@ import static edu.wpi.first.units.Units.DegreesPerSecondPerSecond;
 import static edu.wpi.first.units.Units.Inches;
 import static edu.wpi.first.units.Units.Pounds;
 import static edu.wpi.first.units.Units.RPM;
+import static edu.wpi.first.units.Units.Rotations;
+import static edu.wpi.first.units.Units.RotationsPerSecond;
+import static edu.wpi.first.units.Units.RotationsPerSecondPerSecond;
+import static edu.wpi.first.units.Units.Second;
 import static edu.wpi.first.units.Units.Seconds;
+import static edu.wpi.first.units.Units.Volts;
+import static edu.wpi.first.units.Units.VoltsPerRadianPerSecond;
 import static yams.mechanisms.SmartMechanism.gearbox;
 import static yams.mechanisms.SmartMechanism.gearing;
 
 import com.revrobotics.spark.SparkLowLevel.MotorType;
 import com.revrobotics.spark.SparkMax;
+
 import edu.wpi.first.math.controller.ArmFeedforward;
 import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+
 import java.util.function.Supplier;
+
+import edu.wpi.first.math.controller.SimpleMotorFeedforward;
 import yams.mechanisms.config.ShooterConfig;
 import yams.mechanisms.velocity.Shooter;
 import yams.motorcontrollers.SmartMotorController;
@@ -38,8 +48,7 @@ public class ShooterSubsystem extends SubsystemBase
 //          .withMechanismLowerLimit()
 //          .withMechanismUpperLimit();
   private final SmartMotorControllerConfig motorConfig = new SmartMotorControllerConfig(this)
-      .withClosedLoopController(4, 0, 0, DegreesPerSecond.of(180), DegreesPerSecondPerSecond.of(90))
-      .withSoftLimit(Degrees.of(-30), Degrees.of(100))
+      .withClosedLoopController(0.00016541, 0, 0, RPM.of(5000), RotationsPerSecondPerSecond.of(2500))
       .withGearing(gearing(gearbox(3, 4)))
 //      .withExternalEncoder(armMotor.getAbsoluteEncoder())
       .withIdleMode(MotorMode.COAST)
@@ -50,7 +59,8 @@ public class ShooterSubsystem extends SubsystemBase
       .withMotorInverted(false)
       .withClosedLoopRampRate(Seconds.of(0.25))
       .withOpenLoopRampRate(Seconds.of(0.25))
-      .withFeedforward(new ArmFeedforward(0, 0, 0, 0))
+      .withFeedforward(new SimpleMotorFeedforward(0.27937, 0.089836, 0.014557))
+      .withSimFeedforward(new SimpleMotorFeedforward(0.27937, 0.089836, 0.014557))
       .withControlMode(ControlMode.CLOSED_LOOP);
   private final SmartMotorController       motor       = new SparkWrapper(armMotor, DCMotor.getNEO(1), motorConfig);
 
@@ -58,7 +68,8 @@ public class ShooterSubsystem extends SubsystemBase
       .withDiameter(Inches.of(4))
       .withMass(Pounds.of(1))
       .withTelemetry("ShooterMech", TelemetryVerbosity.HIGH)
-      .withUpperSoftLimit(RPM.of(1000));
+      .withSoftLimit(RPM.of(-500), RPM.of(500))
+      .withSpeedometerSimulation(RPM.of(750));
   private final Shooter       shooter       = new Shooter(shooterConfig);
 
   public ShooterSubsystem() {}
@@ -72,4 +83,16 @@ public class ShooterSubsystem extends SubsystemBase
   public Command setVelocity(Supplier<AngularVelocity> speed) {return shooter.setSpeed(speed);}
 
   public Command setDutyCycle(Supplier<Double> dutyCycle) {return shooter.set(dutyCycle);}
+
+  public Command sysId() {return shooter.sysId(Volts.of(10), Volts.of(1).per(Second), Seconds.of(5));}
+
+  @Override
+  public void periodic() {
+      shooter.updateTelemetry();
+  }
+
+  @Override
+  public void simulationPeriodic() {
+      shooter.simIterate();
+  }
 }

--- a/yams/java/yams/mechanisms/config/ElevatorConfig.java
+++ b/yams/java/yams/mechanisms/config/ElevatorConfig.java
@@ -166,7 +166,7 @@ public class ElevatorConfig
   }
 
   /**
-   * Set the elevator mechnism position configuration.
+   * Set the elevator mechanism position configuration.
    *
    * @param mechanismPositionConfig {@link MechanismPositionConfig} for the {@link yams.mechanisms.positional.Elevator}
    * @return {@link ElevatorConfig} for chaining

--- a/yams/java/yams/motorcontrollers/SmartMotorController.java
+++ b/yams/java/yams/motorcontrollers/SmartMotorController.java
@@ -377,6 +377,11 @@ public abstract class SmartMotorController
           pidOutputVoltage.set(pid.calculate(getMechanismVelocity().in(RotationsPerSecond),
                                              setpointVelocity.get().in(RotationsPerSecond)));
         });
+        if (simpleMotorFeedforward.isPresent())
+        {
+          feedforward = simpleMotorFeedforward.get().calculateWithVelocities(getMechanismVelocity().in(
+            RotationsPerSecond), setpointVelocity.get().in(RotationsPerSecond));
+        }
       }
     }
     if (mechUpperLimit.isPresent())


### PR DESCRIPTION
Introduces speedometer simulation support to ShooterConfig and Shooter, including configuration methods and visualization updates. Implements a proper sysId routine for velocity-based shooter mechanisms. Updates closed-loop controller parameters and feedforward in ShooterSubsystem, and improves SmartMotorController feedforward calculation. Also fixes a typo in ElevatorConfig.

I've been using a speedometer style of simulation for flywheels in the past and wanted to introduce that here. It allows you to set the soft max/mins in the simulation and make them visible. It requires that the user set a simulation max, if they haven't set one of the limits. The dial starts pointed down for 0 and will use the maximum limit as the vertical. Since motors can got +/- velocity, the left hand side represents positive speeds, the right negative. 

I've also taken it upon myself to get the SysID routine working, as well as I can. The values I got from it are in the code for this setup, as an example. I also had to add a feedforward calculation for velocities and I changed the example to use a SimpleFeedForward instead of ArmFF.

There are a few other minor fixes. Let me know if there's anything I've missed.
Thanks!