### PR TITLE
'Trapazoidal' Spelling Error Correction

### DIFF
--- a/examples/simple_robot/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
+++ b/examples/simple_robot/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
@@ -60,7 +60,7 @@ public class ElevatorSubsystem extends SubsystemBase
                                      weight,
                                      radius,
                                      gearing)))
-//      .withClosedLoopController(4, 0, 0, MetersPerSecond.of(0.5), MetersPerSecondPerSecond.of(0.5)) // Trapazoidal Profile PID Controller
+//      .withClosedLoopController(4, 0, 0, MetersPerSecond.of(0.5), MetersPerSecondPerSecond.of(0.5)) // Trapezoidal Profile PID Controller
       .withSoftLimit(Meters.of(0), Meters.of(2))
       .withGearing(gearing)
 //      .withExternalEncoder(armMotor.getAbsoluteEncoder()) // External Encoder if you need one, really shouldnt be used for Elevators

--- a/yams/java/yams/motorcontrollers/SmartMotorController.java
+++ b/yams/java/yams/motorcontrollers/SmartMotorController.java
@@ -827,28 +827,28 @@ public abstract class SmartMotorController
   public abstract void setEncoderInverted(boolean inverted);
 
   /**
-   * Set the maximum velocity of the trapazoidal profile for the feedback controller.
+   * Set the maximum velocity of the trapezoidal profile for the feedback controller.
    *
    * @param maxVelocity Maximum velocity, will be translated to MetersPerSecond.
    */
   public abstract void setMotionProfileMaxVelocity(LinearVelocity maxVelocity);
 
   /**
-   * Set the maximum acceleration of the trapazoidal profile for the feedback controller.
+   * Set the maximum acceleration of the trapezoidal profile for the feedback controller.
    *
    * @param maxAcceleration Maximum acceleration, will be translated to MetersPerSecondPerSecond.
    */
   public abstract void setMotionProfileMaxAcceleration(LinearAcceleration maxAcceleration);
 
   /**
-   * Set the maximum velocity for the trapazoidal profile for the feedback controller.
+   * Set the maximum velocity for the trapezoidal profile for the feedback controller.
    *
    * @param maxVelocity Maximum velocity, will be translated to RotationsPerSecond.
    */
   public abstract void setMotionProfileMaxVelocity(AngularVelocity maxVelocity);
 
   /**
-   * Set the maximum acceleration for the trapazoidal profile for the feedback controller.
+   * Set the maximum acceleration for the trapezoidal profile for the feedback controller.
    *
    * @param maxAcceleration Maximum acceleration, will be translated to RotationsPerSecondPerSecond.
    */

--- a/yams/java/yams/motorcontrollers/SmartMotorControllerConfig.java
+++ b/yams/java/yams/motorcontrollers/SmartMotorControllerConfig.java
@@ -1130,8 +1130,8 @@ public class SmartMotorControllerConfig
    * @param kP              KP scalar for the PID Controller.
    * @param kI              KI scalar for the PID Controller.
    * @param kD              KD scalar for the PID Controller.
-   * @param maxVelocity     Maximum linear velocity for the Trapazoidal profile.
-   * @param maxAcceleration Maximum linear acceleration for the Trapazoidal profile.
+   * @param maxVelocity     Maximum linear velocity for the Trapezoidal profile.
+   * @param maxAcceleration Maximum linear acceleration for the Trapezoidal profile.
    * @return {@link SmartMotorControllerConfig} for chaining.
    */
   public SmartMotorControllerConfig withSimClosedLoopController(double kP, double kI, double kD,
@@ -1256,8 +1256,8 @@ public class SmartMotorControllerConfig
    * @param kP              KP scalar for the PID Controller, the units passed in are in Meters and output is Voltage.
    * @param kI              KI scalar for the PID Controller, the units passed in are in Meters and output is Voltage.
    * @param kD              KD scalar for the PID Controller, the units passed in are in Meters and output is Voltage.
-   * @param maxVelocity     Maximum linear velocity for the Trapazoidal profile.
-   * @param maxAcceleration Maximum linear acceleration for the Trapazoidal profile.
+   * @param maxVelocity     Maximum linear velocity for the Trapezoidal profile.
+   * @param maxAcceleration Maximum linear acceleration for the Trapezoidal profile.
    * @return {@link SmartMotorControllerConfig} for chaining.
    */
   public SmartMotorControllerConfig withClosedLoopController(double kP, double kI, double kD,
@@ -1289,8 +1289,8 @@ public class SmartMotorControllerConfig
    *                        Voltage.
    * @param kD              KD scalar for the PID Controller, the units passed in are in Rotations and output is
    *                        Voltage.
-   * @param maxVelocity     Maximum angular velocity for the Trapazoidal profile.
-   * @param maxAcceleration Maximum angular acceleration for the Trapazoidal profile.
+   * @param maxVelocity     Maximum angular velocity for the Trapezoidal profile.
+   * @param maxAcceleration Maximum angular acceleration for the Trapezoidal profile.
    * @return {@link SmartMotorControllerConfig} for chaining.
    */
   public SmartMotorControllerConfig withClosedLoopController(double kP, double kI, double kD,

--- a/yams/java/yams/motorcontrollers/remote/TalonFXSWrapper.java
+++ b/yams/java/yams/motorcontrollers/remote/TalonFXSWrapper.java
@@ -98,7 +98,7 @@ public class TalonFXSWrapper extends SmartMotorController
    */
   private final VelocityVoltage               m_velocityReq     = new VelocityVoltage(0).withSlot(0);
   /**
-   * Position with trapazoidal profiling request.
+   * Position with trapezoidal profiling request.
    */
   private final MotionMagicVoltage            m_trapPositionReq = new MotionMagicVoltage(0).withSlot(0);
   /**

--- a/yams/java/yams/motorcontrollers/remote/TalonFXWrapper.java
+++ b/yams/java/yams/motorcontrollers/remote/TalonFXWrapper.java
@@ -92,7 +92,7 @@ public class TalonFXWrapper extends SmartMotorController
    */
   private final VelocityVoltage               m_velocityReq     = new VelocityVoltage(0).withSlot(0);
   /**
-   * Position with trapazoidal profiling request.
+   * Position with trapezoidal profiling request.
    */
   private final MotionMagicVoltage            m_trapPositionReq = new MotionMagicVoltage(0).withSlot(0);
   /**


### PR DESCRIPTION
I noticed that there was a spelling mistake and wanted to correct it, so I change 'trapazoidal' to 'trapezoidal' for all instances of the word 