### PR TITLE
Stop the motors in simulation when the pivot hits the hard limits

### DIFF
--- a/yams/java/yams/mechanisms/positional/Pivot.java
+++ b/yams/java/yams/mechanisms/positional/Pivot.java
@@ -377,6 +377,9 @@ public class Pivot extends SmartPositionalMechanism
       m_smc.getSimSupplier().get().starveUpdateSim();
       if (m_config.getLowerHardLimit().isPresent() && m_dcmotorSim.get().getAngularVelocityRadPerSec() < 0 &&
           m_smc.getMechanismPosition().lt(m_config.getLowerHardLimit().get()))
+          // Stop the motor from moving further in the direction of the hard limit
+          m_dcmotorSim.get().setAngularVelocity(0);
+          m_smc.setDutyCycle(0);
       {
         m_smc.setEncoderPosition(m_config.getLowerHardLimit().get());
       }
@@ -384,6 +387,9 @@ public class Pivot extends SmartPositionalMechanism
           m_smc.getMechanismPosition().gt(m_config.getUpperHardLimit().get()))
       {
         m_smc.setEncoderPosition(m_config.getUpperHardLimit().get());
+        // Stop the motor from moving further in the direction of the hard limit
+        m_dcmotorSim.get().setAngularVelocity(0);
+        m_smc.setDutyCycle(0);
       }
       RoboRioSim.setVInVoltage(BatterySim.calculateDefaultBatteryLoadedVoltage(m_dcmotorSim.get()
                                                                                            .getCurrentDrawAmps()));


### PR DESCRIPTION
This pull request adds additional safety checks to the `simIterate` method in `Pivot.java` to ensure that the motor simulation does not exceed its configured hard limits. The main improvement is that the motor's angular velocity and duty cycle are now explicitly set to zero when a hard limit is reached, preventing further movement beyond the limit.

**Simulation safety improvements:**

* In `simIterate`, when the mechanism reaches either the lower or upper hard limit, the motor's angular velocity is set to zero and the duty cycle is stopped, ensuring the simulated motor cannot move past its physical constraints.

Note: Maybe this is a 'hack' solution, IDK. It at least stops the drifting behavior enough to make it act more like reality.