### PR TITLE
Config Optionality Update & Sim Starting Position

### DIFF
--- a/yams/java/yams/gearing/MechanismGearing.java
+++ b/yams/java/yams/gearing/MechanismGearing.java
@@ -9,6 +9,10 @@ public class MechanismGearing
 {
 
   /**
+   * 1:1 Mechanism Gearing.
+   */
+  public static final MechanismGearing kOne = new MechanismGearing(1.0);
+  /**
    * Mechanism gearbox attached to the motor.
    */
   private final GearBox            gearBox;

--- a/yams/java/yams/mechanisms/config/ArmConfig.java
+++ b/yams/java/yams/mechanisms/config/ArmConfig.java
@@ -8,6 +8,7 @@ import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.units.measure.Mass;
 import edu.wpi.first.units.measure.MomentOfInertia;
+import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj.simulation.SingleJointedArmSim;
 import edu.wpi.first.wpilibj.util.Color;
 import edu.wpi.first.wpilibj.util.Color8Bit;
@@ -27,7 +28,7 @@ public class ArmConfig
   /**
    * {@link SmartMotorController} for the {@link yams.mechanisms.positional.Arm}
    */
-  private Optional<SmartMotorController> motor = Optional.empty();
+  private Optional<SmartMotorController> motor               = Optional.empty();
   /**
    * The network root of the mechanism (Optional).
    */
@@ -77,6 +78,10 @@ public class ArmConfig
    */
   private   Optional<Angle>                startingPosition        = Optional.empty();
   /**
+   * Simulated starting position.
+   */
+  private Optional<Angle>                simStartingPosition = Optional.empty();
+  /**
    * Lower and upper soft limits of the arms closed loop controller. (LowerLimit, UpperLimit)
    */
   private   Optional<Pair<Angle, Angle>>   softLimits              = Optional.empty();
@@ -108,6 +113,7 @@ public class ArmConfig
    */
   private ArmConfig(ArmConfig cfg)
   {
+    this.simStartingPosition = cfg.simStartingPosition;
     motor = cfg.motor;
     networkTableName = cfg.networkTableName;
     telemetryName = cfg.telemetryName;
@@ -129,6 +135,18 @@ public class ArmConfig
   public ArmConfig clone()
   {
     return new ArmConfig(this);
+  }
+
+  /**
+   * Set the simulation starting position of the arm. Only ever used in simulation.
+   *
+   * @param simStartingPosition {@link Angle} of the starting position of the arm.
+   * @return {@link ArmConfig} for chaining.
+   */
+  public ArmConfig withSimStartingPosition(Angle simStartingPosition)
+  {
+    this.simStartingPosition = Optional.ofNullable(simStartingPosition);
+    return this;
   }
 
   /**
@@ -433,6 +451,10 @@ public class ArmConfig
    */
   public Optional<Angle> getStartingAngle()
   {
+    if (RobotBase.isSimulation() && simStartingPosition.isPresent())
+    {
+      return simStartingPosition;
+    }
     return startingPosition;
   }
 

--- a/yams/java/yams/mechanisms/config/ElevatorConfig.java
+++ b/yams/java/yams/mechanisms/config/ElevatorConfig.java
@@ -6,6 +6,7 @@ import edu.wpi.first.math.Pair;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.units.measure.Mass;
+import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj.util.Color;
 import edu.wpi.first.wpilibj.util.Color8Bit;
 import java.util.Optional;
@@ -24,64 +25,68 @@ public class ElevatorConfig
   /**
    * {@link SmartMotorController} for the {@link yams.mechanisms.positional.Elevator}
    */
-  private Optional<SmartMotorController>         motor = Optional.empty();
+  private   Optional<SmartMotorController>     motor                   = Optional.empty();
   /**
    * The network root of the mechanism (Optional).
    */
   @Deprecated
-  protected     Optional<String>             networkRoot             = Optional.empty();
+  protected Optional<String>                   networkRoot             = Optional.empty();
   /**
    * Telemetry name.
    */
-  private       Optional<String>             telemetryName           = Optional.empty();
+  private   Optional<String>                   telemetryName           = Optional.empty();
   /**
    * Telemetry verbosity
    */
-  private       Optional<TelemetryVerbosity> telemetryVerbosity      = Optional.empty();
+  private   Optional<TelemetryVerbosity>       telemetryVerbosity      = Optional.empty();
   /**
    * Lower Hard Limit for the {@link yams.mechanisms.positional.Elevator} to be representing in simulation.
    */
-  private       Optional<Distance>           lowerHardLimit          = Optional.empty();
+  private   Optional<Distance>                 lowerHardLimit          = Optional.empty();
   /**
    * Upper hard limit for the {@link yams.mechanisms.positional.Elevator} representing in simulation.
    */
-  private       Optional<Distance>           upperHardLimit          = Optional.empty();
+  private   Optional<Distance>                 upperHardLimit          = Optional.empty();
   /**
    * {@link yams.mechanisms.positional.Elevator} angle for simulation.
    */
-  private       Angle                        angle                   = Degrees.of(90);
+  private   Angle                              angle                   = Degrees.of(90);
   /**
    * {@link yams.mechanisms.positional.Elevator} carriage mass for simulation.
    */
-  private       Optional<Mass>               carriageWeight          = Optional.empty();
+  private   Optional<Mass>                     carriageWeight          = Optional.empty();
   /**
    * Sim color value
    */
-  private       Color8Bit                    simColor                = new Color8Bit(Color.kOrange);
+  private   Color8Bit                          simColor                = new Color8Bit(Color.kOrange);
   /**
    * Mechanism position configuration for the {@link yams.mechanisms.positional.Pivot} (Optional).
    */
-  private       MechanismPositionConfig mechanismPositionConfig = new MechanismPositionConfig();
+  private   MechanismPositionConfig            mechanismPositionConfig = new MechanismPositionConfig();
   /**
    * Drum radius of the elevator spool, or the sprocket pitch * teeth.
    */
-  private Optional<Distance>            drumCircumference       = Optional.empty();
+  private   Optional<Distance>                 drumCircumference       = Optional.empty();
   /**
    * Elevator stages, applied to the motor controller config gearing by dividing it by the number of stages given.
    */
-  private OptionalInt                   stages                  = OptionalInt.empty();
+  private   OptionalInt                        stages                  = OptionalInt.empty();
   /**
    * Starting height to set the motor's encoder to.
    */
-  private Optional<Distance> startingHeight = Optional.empty();
+  private   Optional<Distance>                 startingHeight          = Optional.empty();
+  /**
+   * Simulated starting height.
+   */
+  private   Optional<Distance>                 simStartingHeight       = Optional.empty();
   /**
    * Soft limits of the {@link SmartMotorController} closed loop controller. Can be exceeded. (LowerLimit, UpperLimit)
    */
-  private Optional<Pair<Distance, Distance>> softLimits = Optional.empty();
+  private   Optional<Pair<Distance, Distance>> softLimits              = Optional.empty();
   /**
    * Disable gravity on the elevator simulation.
    */
-  private boolean       isElevatorHorizontal          = false;
+  private   boolean                            isElevatorHorizontal    = false;
 
   /**
    * Elevator Configuration class
@@ -108,6 +113,8 @@ public class ElevatorConfig
    */
   private ElevatorConfig(ElevatorConfig cfg)
   {
+    this.isElevatorHorizontal = cfg.isElevatorHorizontal;
+    this.simStartingHeight = cfg.simStartingHeight;
     this.motor = cfg.motor;
     this.drumCircumference = cfg.drumCircumference;
     this.stages = cfg.stages;
@@ -131,6 +138,18 @@ public class ElevatorConfig
   }
 
   /**
+   * Set the simulated starting height of the elevator. Only used during simulation.
+   *
+   * @param height {@link Distance} of the elevator on start.
+   * @return {@link ElevatorConfig} for chaining.
+   */
+  public ElevatorConfig withSimStartingHeight(Distance height)
+  {
+    simStartingHeight = Optional.ofNullable(height);
+    return this;
+  }
+
+  /**
    * Set the {@link SmartMotorController} for the {@link yams.mechanisms.positional.Elevator}
    *
    * @param motorController Primary {@link SmartMotorController} for the {@link yams.mechanisms.positional.Elevator}
@@ -139,10 +158,10 @@ public class ElevatorConfig
   public ElevatorConfig withSmartMotorController(SmartMotorController motorController)
   {
     motor = Optional.of(motorController);
-    drumCircumference.ifPresent(drumRadius->motor.get().getConfig().withMechanismCircumference(drumRadius));
+    drumCircumference.ifPresent(drumRadius -> motor.get().getConfig().withMechanismCircumference(drumRadius));
     stages.ifPresent(this::withCascadingElevatorStages);
     startingHeight.ifPresent(this::withStartingHeight);
-    softLimits.ifPresent(softLimits->withSoftLimits(softLimits.getFirst(), softLimits.getSecond()));
+    softLimits.ifPresent(softLimits -> withSoftLimits(softLimits.getFirst(), softLimits.getSecond()));
     return this;
   }
 
@@ -276,10 +295,9 @@ public class ElevatorConfig
   public ElevatorConfig withStartingHeight(Distance startingPosition)
   {
     startingHeight = Optional.ofNullable(startingPosition);
-    motor.ifPresent(motor->motor.getConfig().withStartingPosition(startingPosition));
+    motor.ifPresent(motor -> motor.getConfig().withStartingPosition(startingPosition));
     return this;
   }
-
 
 
   /**
@@ -291,8 +309,8 @@ public class ElevatorConfig
    */
   public ElevatorConfig withSoftLimits(Distance lowerLimit, Distance upperLimit)
   {
-    softLimits = Optional.of(Pair.of(lowerLimit,upperLimit));
-    motor.ifPresent(motor->motor.getConfig().withSoftLimit(lowerLimit, upperLimit));
+    softLimits = Optional.of(Pair.of(lowerLimit, upperLimit));
+    motor.ifPresent(motor -> motor.getConfig().withSoftLimit(lowerLimit, upperLimit));
     return this;
   }
 
@@ -312,8 +330,7 @@ public class ElevatorConfig
 
   /**
    * Set elevator as horizontal to avoid gravity simulation
-   * 
-   * 
+   *
    * @return {@link ElevatorConfig} for chaining.
    */
   public ElevatorConfig withHorizontalElevator()
@@ -389,11 +406,18 @@ public class ElevatorConfig
    */
   public Optional<Distance> getStartingHeight()
   {
-    return motor.orElseThrow().getConfig().getStartingPosition().isPresent() ? Optional.of(motor.orElseThrow().getConfig()
-                                                                                  .convertFromMechanism(motor.orElseThrow().getConfig()
-                                                                                                             .getStartingPosition()
-                                                                                                             .get()))
-                                                               : Optional.empty();
+    if (RobotBase.isSimulation() && simStartingHeight.isPresent())
+    {
+      return simStartingHeight;
+    }
+    return motor.orElseThrow().getConfig().getStartingPosition().isPresent() ? Optional.of(motor.orElseThrow()
+                                                                                                .getConfig()
+                                                                                                .convertFromMechanism(
+                                                                                                    motor.orElseThrow()
+                                                                                                         .getConfig()
+                                                                                                         .getStartingPosition()
+                                                                                                         .get()))
+                                                                             : Optional.empty();
   }
 
   /**

--- a/yams/java/yams/mechanisms/config/PivotConfig.java
+++ b/yams/java/yams/mechanisms/config/PivotConfig.java
@@ -68,6 +68,10 @@ public class PivotConfig
    */
   private   Optional<Angle>                startingPosition        = Optional.empty();
   /**
+   * Simulated starting position.
+   */
+  private Optional<Angle> simStartingPosition = Optional.empty();
+  /**
    * Soft limits of the pivot motor {@link SmartMotorController} closed loop controller. (LowerLimit, UpperLimit)
    */
   private   Optional<Pair<Angle, Angle>>   softLimits              = Optional.empty();
@@ -104,6 +108,7 @@ public class PivotConfig
    */
   public PivotConfig(PivotConfig cfg)
   {
+    this.simStartingPosition = cfg.simStartingPosition;
     this.motor = cfg.motor;
     this.networkRoot = cfg.networkRoot;
     this.telemetryName = cfg.telemetryName;
@@ -122,6 +127,18 @@ public class PivotConfig
   public PivotConfig clone()
   {
     return new PivotConfig(this);
+  }
+
+  /**
+   * Set the simulation starting position of the pivot. Only ever used in simulation.
+   *
+   * @param position {@link Angle} of the starting position of the pivot.
+   * @return {@link PivotConfig} for chaining.
+   */
+  public PivotConfig withSimStartingPosition(Angle position)
+  {
+    this.simStartingPosition = Optional.ofNullable(position);
+    return this;
   }
 
   /**
@@ -162,7 +179,8 @@ public class PivotConfig
    * Configure the MOI directly instead of estimating it with the length and mass of the
    * {@link yams.mechanisms.positional.Pivot} for simulation.
    *
-   * @param MOI Moment of Inertia of the {@link yams.mechanisms.positional.Pivot}. in {@link edu.wpi.first.units.Units#KilogramSquareMeters}
+   * @param MOI Moment of Inertia of the {@link yams.mechanisms.positional.Pivot}. in
+   *            {@link edu.wpi.first.units.Units#KilogramSquareMeters}
    * @return {@link PivotConfig} for chaining.
    * @implNote Please use {@link #withMOI(MomentOfInertia)} instead. Default unit is KilogramSquareMeters
    */

--- a/yams/java/yams/motorcontrollers/SmartMotorControllerConfig.java
+++ b/yams/java/yams/motorcontrollers/SmartMotorControllerConfig.java
@@ -13,7 +13,6 @@ import static edu.wpi.first.units.Units.Rotations;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.RotationsPerSecondPerSecond;
 import static edu.wpi.first.units.Units.Second;
-import static edu.wpi.first.units.Units.Seconds;
 import static edu.wpi.first.units.Units.Volts;
 
 import edu.wpi.first.hal.HAL;
@@ -69,7 +68,7 @@ public class SmartMotorControllerConfig
   /**
    * Reset old configurations, so they are no longer persistent.
    */
-  private boolean          resetPreviousConfig        = true;
+  private boolean                    resetPreviousConfig        = true;
   /**
    * Vendor specific configuration for the {@link SmartMotorController}.
    */
@@ -77,7 +76,7 @@ public class SmartMotorControllerConfig
   /**
    * Vendor specific control request for the {@link SmartMotorController}
    */
-  private Optional<Object> vendorControlRequest       = Optional.empty();
+  private Optional<Object>           vendorControlRequest       = Optional.empty();
   /**
    * Subsystem that the {@link SmartMotorController} controls.
    */
@@ -104,7 +103,7 @@ public class SmartMotorControllerConfig
   /**
    * External encoder inversion state.
    */
-  private       boolean                                       externalEncoderInverted            = false;
+  private Optional<Boolean>          externalEncoderInverted    = Optional.empty();
   /**
    * Follower motors and inversion.
    */
@@ -172,8 +171,7 @@ public class SmartMotorControllerConfig
   /**
    * External encoder gearing, defaults to 1:1.
    */
-  private       MechanismGearing                              externalEncoderGearing             = new MechanismGearing(
-      1);
+  private Optional<MechanismGearing> externalEncoderGearing     = Optional.empty();
   /**
    * Mechanism Circumference for distance calculations.
    */
@@ -185,11 +183,11 @@ public class SmartMotorControllerConfig
   /**
    * Open loop ramp rate, amount of time to go from 0 to 100 speed..
    */
-  private       Time                                          openLoopRampRate                   = Seconds.of(0);
+  private Optional<Time>             openLoopRampRate           = Optional.empty();
   /**
    * Closed loop ramp rate, amount of time to go from 0 to 100 speed.
    */
-  private       Time                                          closeLoopRampRate                  = Seconds.of(0);
+  private Optional<Time>             closeLoopRampRate          = Optional.empty();
   /**
    * Set the stator current limit in Amps for the {@link SmartMotorController}
    */
@@ -237,11 +235,11 @@ public class SmartMotorControllerConfig
   /**
    * The encoder readings are inverted.
    */
-  private       boolean                                       encoderInverted                    = false;
+  private Optional<Boolean>          encoderInverted            = Optional.empty();
   /**
    * The motor is inverted.
    */
-  private       boolean                                       motorInverted                      = false;
+  private Optional<Boolean>          motorInverted              = Optional.empty();
   /**
    * Use the provided external encoder if set.
    */
@@ -253,7 +251,7 @@ public class SmartMotorControllerConfig
   /**
    * {@link SmartMotorController} starting angle to be used during simulation.
    */
-  private Optional<Angle>  sim_startingPosition       = Optional.empty();
+  private Optional<Angle>            sim_startingPosition       = Optional.empty();
   /**
    * Maximum voltage output for the motor controller while using the closed loop controller.
    */
@@ -290,11 +288,11 @@ public class SmartMotorControllerConfig
   /**
    * Linear or {@link Distance} based closed loop controller.
    */
-  private boolean          linearClosedLoopController = false;
+  private boolean                    linearClosedLoopController = false;
   /**
    * Velocity trapezoidal profile.
    */
-  private boolean          velocityTrapezoidalProfile = false;
+  private boolean                    velocityTrapezoidalProfile = false;
 
   /**
    * Construct the {@link SmartMotorControllerConfig} for the {@link Subsystem}
@@ -444,7 +442,7 @@ public class SmartMotorControllerConfig
    */
   public SmartMotorControllerConfig withExternalEncoderInverted(boolean externalEncoderInverted)
   {
-    this.externalEncoderInverted = externalEncoderInverted;
+    this.externalEncoderInverted = Optional.of(externalEncoderInverted);
     return this;
   }
 
@@ -559,7 +557,7 @@ public class SmartMotorControllerConfig
    */
   public SmartMotorControllerConfig withEncoderInverted(boolean inverted)
   {
-    this.encoderInverted = inverted;
+    this.encoderInverted = Optional.of(inverted);
     return this;
   }
 
@@ -571,7 +569,7 @@ public class SmartMotorControllerConfig
    */
   public SmartMotorControllerConfig withMotorInverted(boolean motorInverted)
   {
-    this.motorInverted = motorInverted;
+    this.motorInverted = Optional.of(motorInverted);
     return this;
   }
 
@@ -1043,7 +1041,7 @@ public class SmartMotorControllerConfig
    */
   public SmartMotorControllerConfig withClosedLoopRampRate(Time rate)
   {
-    this.closeLoopRampRate = rate;
+    this.closeLoopRampRate = Optional.of(rate);
     return this;
   }
 
@@ -1056,7 +1054,7 @@ public class SmartMotorControllerConfig
    */
   public SmartMotorControllerConfig withOpenLoopRampRate(Time rate)
   {
-    this.openLoopRampRate = rate;
+    this.openLoopRampRate = Optional.of(rate);
     return this;
   }
 
@@ -2004,7 +2002,7 @@ public class SmartMotorControllerConfig
    *
    * @return Open loop ramp rate.
    */
-  public Time getOpenLoopRampRate()
+  public Optional<Time> getOpenLoopRampRate()
   {
     basicOptions.remove(BasicOptions.OpenLoopRampRate);
     return openLoopRampRate;
@@ -2015,7 +2013,7 @@ public class SmartMotorControllerConfig
    *
    * @return Closed loop ramp.
    */
-  public Time getClosedLoopRampRate()
+  public Optional<Time> getClosedLoopRampRate()
   {
     basicOptions.remove(BasicOptions.ClosedLoopRampRate);
     return closeLoopRampRate;
@@ -2237,7 +2235,7 @@ public class SmartMotorControllerConfig
    *
    * @return encoder inversion state
    */
-  public boolean getEncoderInverted()
+  public Optional<Boolean> getEncoderInverted()
   {
     basicOptions.remove(BasicOptions.EncoderInverted);
     return encoderInverted;
@@ -2248,11 +2246,11 @@ public class SmartMotorControllerConfig
    *
    * @return moto inversion state.
    */
-  public boolean getMotorInverted()
+  public Optional<Boolean> getMotorInverted()
   {
     basicOptions.remove(BasicOptions.MotorInverted);
     if (RobotBase.isSimulation())
-    {return false;}
+    {return Optional.of(false);}
     return motorInverted;
   }
 
@@ -2320,7 +2318,7 @@ public class SmartMotorControllerConfig
    *
    * @return External encoder gearing.
    */
-  public MechanismGearing getExternalEncoderGearing()
+  public Optional<MechanismGearing> getExternalEncoderGearing()
   {
     externalEncoderOptions.remove(ExternalEncoderOptions.ExternalGearing);
     return externalEncoderGearing;
@@ -2343,7 +2341,7 @@ public class SmartMotorControllerConfig
           "You have been warned! (^.^) - Rivet",
           true);
     }
-    this.externalEncoderGearing = externalEncoderGearing;
+    this.externalEncoderGearing = Optional.of(externalEncoderGearing);
     return this;
   }
 
@@ -2364,7 +2362,7 @@ public class SmartMotorControllerConfig
           "You have been warned! (^.^) - Rivet",
           true);
     }
-    this.externalEncoderGearing = new MechanismGearing(reductionRatio);
+    this.externalEncoderGearing = Optional.of(new MechanismGearing(reductionRatio));
     return this;
   }
 
@@ -2505,11 +2503,11 @@ public class SmartMotorControllerConfig
    *
    * @return External encoder inversion state
    */
-  public boolean getExternalEncoderInverted()
+  public Optional<Boolean> getExternalEncoderInverted()
   {
     externalEncoderOptions.remove(ExternalEncoderOptions.ExternalEncoderInverted);
     if (RobotBase.isSimulation())
-    {return false;}
+    {return Optional.of(false);}
     return externalEncoderInverted;
   }
 

--- a/yams/java/yams/motorcontrollers/SmartMotorControllerConfig.java
+++ b/yams/java/yams/motorcontrollers/SmartMotorControllerConfig.java
@@ -2249,7 +2249,7 @@ public class SmartMotorControllerConfig
   public Optional<Boolean> getMotorInverted()
   {
     basicOptions.remove(BasicOptions.MotorInverted);
-    if (RobotBase.isSimulation())
+    if (RobotBase.isSimulation() && motorInverted.isPresent())
     {return Optional.of(false);}
     return motorInverted;
   }
@@ -2506,7 +2506,7 @@ public class SmartMotorControllerConfig
   public Optional<Boolean> getExternalEncoderInverted()
   {
     externalEncoderOptions.remove(ExternalEncoderOptions.ExternalEncoderInverted);
-    if (RobotBase.isSimulation())
+    if (RobotBase.isSimulation() && externalEncoderInverted.isPresent())
     {return Optional.of(false);}
     return externalEncoderInverted;
   }

--- a/yams/java/yams/motorcontrollers/local/NovaWrapper.java
+++ b/yams/java/yams/motorcontrollers/local/NovaWrapper.java
@@ -318,9 +318,13 @@ public class NovaWrapper extends SmartMotorController
 
     // Ramp rates
 //    m_nova_config.rampDown = m_nova_config.rampUp = config.getClosedLoopRampRate().in(Seconds);
-    m_nova.setRampUp(config.getClosedLoopRampRate().in(Seconds));
-    m_nova.setRampDown(config.getClosedLoopRampRate().in(Seconds));
-    if (config.getOpenLoopRampRate().gt(Seconds.of(0)))
+    config.getClosedLoopRampRate().ifPresent(rampRate -> {
+      m_nova.setRampUp(rampRate.in(Seconds));
+      m_nova.setRampDown(rampRate.in(Seconds));
+      m_nova_config.rampUp = rampRate.in(Seconds);
+      m_nova_config.rampDown = rampRate.in(Seconds);
+    });
+    if (config.getOpenLoopRampRate().isPresent())
     {
       throw new IllegalArgumentException(
           "[Error] ThriftyNova does not support separate closed loop and open loop ramp rates, using the SmartMotorControllerConfig.withClosedLoopRampRate() as both.");
@@ -330,9 +334,11 @@ public class NovaWrapper extends SmartMotorController
     // Do nothing since not supported yet.
 
     // Inversions
-    m_nova_config.inverted = config.getMotorInverted();
-    m_nova.setInverted(config.getMotorInverted());
-    if (config.getEncoderInverted())
+    config.getMotorInverted().ifPresent(inverted -> {
+      m_nova.setInverted(inverted);
+      m_nova_config.inverted = inverted;
+    });
+    if (config.getEncoderInverted().isPresent())
     {
       throw new IllegalArgumentException("[ERROR] ThriftyNova does not support encoder inversions.");
     }
@@ -398,7 +404,7 @@ public class NovaWrapper extends SmartMotorController
                                                              ".withExternalEncoderZeroOffset");
 //        m_nova.setAbsOffset(config.getZeroOffset().get().in(Rotations));
       }
-      if (config.getExternalEncoderGearing().getRotorToMechanismRatio() != 1.0)
+      if (config.getExternalEncoderGearing().isPresent())
       {
         // Do nothing, applied later.
       }
@@ -412,7 +418,7 @@ public class NovaWrapper extends SmartMotorController
                                                              ".withExternalEncoderZeroOffset");
       }
 
-      if (config.getExternalEncoderGearing().getRotorToMechanismRatio() != 1.0)
+      if (config.getExternalEncoderGearing().isPresent())
       {
         throw new SmartMotorControllerConfigurationException(
             "External encoder gearing is not supported when there is no external encoder",
@@ -421,7 +427,7 @@ public class NovaWrapper extends SmartMotorController
       }
     }
 
-    if (config.getExternalEncoderInverted())
+    if (config.getExternalEncoderInverted().isPresent())
     {
       throw new SmartMotorControllerConfigurationException(
           "External encoder cannot be inverted because no external encoder exists",
@@ -562,7 +568,7 @@ public class NovaWrapper extends SmartMotorController
         // There should be an alert thrown here; but Alerts are not thread-safe.
         return RotationsPerSecond.of(
             m_velocityConversion.fromMotor(m_nova.getVelocityQuad()) *
-            m_config.getExternalEncoderGearing().getRotorToMechanismRatio());
+            m_config.getExternalEncoderGearing().orElse(MechanismGearing.kOne).getRotorToMechanismRatio());
       }
     }
     return getRotorVelocity().times(m_gearing.getRotorToMechanismRatio());
@@ -581,11 +587,13 @@ public class NovaWrapper extends SmartMotorController
       if (externalEncoder == EncoderType.ABS)
       {
         return Rotations.of(m_positionConversion.fromMotor(m_nova.getPositionAbs()) *
-                            m_config.getExternalEncoderGearing().getRotorToMechanismRatio());
+                            m_config.getExternalEncoderGearing().orElse(MechanismGearing.kOne)
+                                    .getRotorToMechanismRatio());
       } else if (externalEncoder == EncoderType.QUAD)
       {
         return Rotations.of(m_positionConversion.fromMotor(m_nova.getPositionQuad()) *
-                            m_config.getExternalEncoderGearing().getRotorToMechanismRatio());
+                            m_config.getExternalEncoderGearing().orElse(MechanismGearing.kOne)
+                                    .getRotorToMechanismRatio());
       }
     }
     return getRotorPosition().times(m_gearing.getRotorToMechanismRatio());

--- a/yams/java/yams/motorcontrollers/local/SparkWrapper.java
+++ b/yams/java/yams/motorcontrollers/local/SparkWrapper.java
@@ -66,6 +66,7 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.function.Supplier;
 import yams.exceptions.SmartMotorControllerConfigurationException;
+import yams.gearing.MechanismGearing;
 import yams.motorcontrollers.SmartMotorController;
 import yams.motorcontrollers.SmartMotorControllerConfig;
 import yams.motorcontrollers.SmartMotorControllerConfig.ControlMode;
@@ -451,9 +452,9 @@ public class SparkWrapper extends SmartMotorController
     double velocityConversionFactor = config.getGearing().getRotorToMechanismRatio() / 60.0;
 
     // Set base config options
-    m_sparkBaseConfig.openLoopRampRate(config.getOpenLoopRampRate().in(Seconds))
-                     .closedLoopRampRate(config.getClosedLoopRampRate().in(Seconds))
-                     .inverted(config.getMotorInverted());
+    config.getOpenLoopRampRate().ifPresent(rate -> m_sparkBaseConfig.openLoopRampRate(rate.in(Seconds)));
+    config.getClosedLoopRampRate().ifPresent(rate -> m_sparkBaseConfig.closedLoopRampRate(rate.in(Seconds)));
+    config.getMotorInverted().ifPresent(m_sparkBaseConfig::inverted);
     m_sparkBaseConfig.encoder.positionConversionFactor(positionConversionFactor)
                              .velocityConversionFactor(velocityConversionFactor);
 
@@ -560,11 +561,12 @@ public class SparkWrapper extends SmartMotorController
       Object externalEncoder = config.getExternalEncoder().get();
       if (externalEncoder instanceof SparkAbsoluteEncoder)
       {
-        double absoluteEncoderConversionFactor = config.getExternalEncoderGearing().getRotorToMechanismRatio();
+        double absoluteEncoderConversionFactor = config.getExternalEncoderGearing().orElse(MechanismGearing.kOne)
+                                                       .getRotorToMechanismRatio();
         m_sparkAbsoluteEncoder = Optional.of((SparkAbsoluteEncoder) externalEncoder);
         m_sparkBaseConfig.absoluteEncoder.positionConversionFactor(absoluteEncoderConversionFactor)
-                                         .velocityConversionFactor(absoluteEncoderConversionFactor / 60)
-                                         .inverted(config.getExternalEncoderInverted());
+                                         .velocityConversionFactor(absoluteEncoderConversionFactor / 60);
+        config.getExternalEncoderInverted().ifPresent(m_sparkBaseConfig.absoluteEncoder::inverted);
         // Set the absolute encoder as the primary feedback sensor for closed loop control.
         m_sparkBaseConfig.closedLoop.feedbackSensor(FeedbackSensor.kAbsoluteEncoder);
 
@@ -614,7 +616,7 @@ public class SparkWrapper extends SmartMotorController
                                                              ".withExternalEncoderZeroOffset");
       }
 
-      if (config.getExternalEncoderInverted())
+      if (config.getExternalEncoderInverted().isPresent())
       {
         throw new SmartMotorControllerConfigurationException(
             "External encoder cannot be inverted because no external encoder exists",
@@ -622,7 +624,7 @@ public class SparkWrapper extends SmartMotorController
             "withExternalEncoderInverted");
       }
 
-      if (config.getExternalEncoderGearing().getRotorToMechanismRatio() != 1.0)
+      if (config.getExternalEncoderGearing().isPresent())
       {
         throw new SmartMotorControllerConfigurationException(
             "External encoder gearing is not supported when there is no external encoder",
@@ -666,7 +668,7 @@ public class SparkWrapper extends SmartMotorController
                                                            ".withZeroOffset");
     }
 
-    if (config.getExternalEncoderInverted() && config.getExternalEncoder().isEmpty() && !useExternalEncoder)
+    if (config.getExternalEncoderInverted().isPresent() && config.getExternalEncoder().isEmpty() && !useExternalEncoder)
     {
       throw new SmartMotorControllerConfigurationException(
           "External encoder cannot be inverted because no external encoder exists",
@@ -674,7 +676,7 @@ public class SparkWrapper extends SmartMotorController
           "withExternalEncoderInverted");
     }
 
-    if (config.getExternalEncoderGearing().getRotorToMechanismRatio() != 1.0 && config.getExternalEncoder().isEmpty() &&
+    if (config.getExternalEncoderGearing().isPresent() && config.getExternalEncoder().isEmpty() &&
         !useExternalEncoder)
     {
       throw new SmartMotorControllerConfigurationException(
@@ -717,7 +719,7 @@ public class SparkWrapper extends SmartMotorController
           "withFeedbackSynchronizationThreshold");
     }
 
-    if (config.getEncoderInverted())
+    if (config.getEncoderInverted().isPresent())
     {
       throw new IllegalArgumentException("[ERROR] Spark relative encoder cannot be inverted!");
     }

--- a/yams/java/yams/motorcontrollers/remote/TalonFXSWrapper.java
+++ b/yams/java/yams/motorcontrollers/remote/TalonFXSWrapper.java
@@ -82,6 +82,7 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.function.Supplier;
 import yams.exceptions.SmartMotorControllerConfigurationException;
+import yams.gearing.MechanismGearing;
 import yams.motorcontrollers.SmartMotorController;
 import yams.motorcontrollers.SmartMotorControllerConfig;
 import yams.motorcontrollers.SmartMotorControllerConfig.ControlMode;
@@ -344,9 +345,11 @@ public class TalonFXSWrapper extends SmartMotorController
         var cancoderSim = m_cancoder.get().getSimState();
         cancoderSim.setSupplyVoltage(m_simSupplier.get().getMechanismSupplyVoltage());
         cancoderSim.setVelocity(m_simSupplier.get().getMechanismVelocity()
-                                             .times(m_config.getExternalEncoderGearing().getMechanismToRotorRatio()));
+                                             .times(m_config.getExternalEncoderGearing().orElse(MechanismGearing.kOne)
+                                                            .getMechanismToRotorRatio()));
         cancoderSim.setRawPosition(m_simSupplier.get().getMechanismPosition()
                                                 .times(m_config.getExternalEncoderGearing()
+                                                               .orElse(MechanismGearing.kOne)
                                                                .getMechanismToRotorRatio()));
         cancoderSim.setMagnetHealth(MagnetHealthValue.Magnet_Green);
       }
@@ -359,18 +362,22 @@ public class TalonFXSWrapper extends SmartMotorController
           candiSim.setPwm1Connected(true);
           candiSim.setPwm1Position(m_simSupplier.get().getMechanismPosition()
                                                 .times(m_config.getExternalEncoderGearing()
+                                                               .orElse(MechanismGearing.kOne)
                                                                .getMechanismToRotorRatio()));
           candiSim.setPwm1Velocity(m_simSupplier.get().getMechanismVelocity()
                                                 .times(m_config.getExternalEncoderGearing()
+                                                               .orElse(MechanismGearing.kOne)
                                                                .getMechanismToRotorRatio()));
         } else if (useCANdiPWM2())
         {
           candiSim.setPwm2Connected(true);
           candiSim.setPwm2Position(m_simSupplier.get().getMechanismPosition()
                                                 .times(m_config.getExternalEncoderGearing()
+                                                               .orElse(MechanismGearing.kOne)
                                                                .getMechanismToRotorRatio()));
           candiSim.setPwm2Velocity(m_simSupplier.get().getMechanismVelocity()
                                                 .times(m_config.getExternalEncoderGearing()
+                                                               .orElse(MechanismGearing.kOne)
                                                                .getMechanismToRotorRatio()));
         }
       }
@@ -760,8 +767,10 @@ public class TalonFXSWrapper extends SmartMotorController
     }
 
     // Motor inversion
-    m_talonConfig.MotorOutput.Inverted =
-        config.getMotorInverted() ? InvertedValue.Clockwise_Positive : InvertedValue.CounterClockwise_Positive;
+    config.getMotorInverted().ifPresent(inverted -> {
+      m_talonConfig.MotorOutput.Inverted =
+          inverted ? InvertedValue.Clockwise_Positive : InvertedValue.CounterClockwise_Positive;
+    });
     // Idle mode
     if (config.getIdleMode().isPresent())
     {
@@ -775,12 +784,13 @@ public class TalonFXSWrapper extends SmartMotorController
       m_talonConfig.Voltage.withPeakReverseVoltage(config.getClosedLoopControllerMaximumVoltage().get().times(-1));
     }
     // Ramp rates
-    m_talonConfig.ClosedLoopRamps.withDutyCycleClosedLoopRampPeriod(config.getClosedLoopRampRate());
-    m_talonConfig.OpenLoopRamps.withDutyCycleOpenLoopRampPeriod(config.getOpenLoopRampRate());
-    m_talonConfig.ClosedLoopRamps.withVoltageClosedLoopRampPeriod(config.getClosedLoopRampRate());
-    m_talonConfig.OpenLoopRamps.withVoltageOpenLoopRampPeriod(config.getOpenLoopRampRate());
-    m_talonConfig.ClosedLoopRamps.withTorqueClosedLoopRampPeriod(config.getClosedLoopRampRate());
-    m_talonConfig.OpenLoopRamps.withTorqueOpenLoopRampPeriod(config.getOpenLoopRampRate());
+    config.getClosedLoopRampRate().ifPresent(m_talonConfig.ClosedLoopRamps::withDutyCycleClosedLoopRampPeriod);
+    config.getOpenLoopRampRate().ifPresent(m_talonConfig.OpenLoopRamps::withDutyCycleOpenLoopRampPeriod);
+    config.getClosedLoopRampRate().ifPresent(m_talonConfig.ClosedLoopRamps::withVoltageClosedLoopRampPeriod);
+    config.getOpenLoopRampRate().ifPresent(m_talonConfig.OpenLoopRamps::withVoltageOpenLoopRampPeriod);
+    config.getClosedLoopRampRate().ifPresent(m_talonConfig.ClosedLoopRamps::withTorqueClosedLoopRampPeriod);
+    config.getOpenLoopRampRate().ifPresent(m_talonConfig.OpenLoopRamps::withTorqueOpenLoopRampPeriod);
+
     // Current limits
     if (config.getStatorStallCurrentLimit().isPresent())
     {
@@ -819,9 +829,11 @@ public class TalonFXSWrapper extends SmartMotorController
       // Set the gear ratio for external encoders.
       m_talonConfig.ExternalFeedback.RotorToSensorRatio = config.getGearing().getMechanismToRotorRatio() *
                                                           config.getExternalEncoderGearing()
+                                                                .orElse(MechanismGearing.kOne)
                                                                 .getRotorToMechanismRatio();
       // config.getExternalEncoderGearing().getMechanismToRotorRatio() *
       m_talonConfig.ExternalFeedback.SensorToMechanismRatio = config.getExternalEncoderGearing()
+                                                                    .orElse(MechanismGearing.kOne)
                                                                     .getMechanismToRotorRatio();
       if (config.getExternalEncoder().get() instanceof CANcoder encoder)
       {
@@ -830,9 +842,11 @@ public class TalonFXSWrapper extends SmartMotorController
         var cfg          = new CANcoderConfiguration();
         configurator.refresh(cfg);
         m_talonConfig.ExternalFeedback.FeedbackRemoteSensorID = encoder.getDeviceID();
-        cfg.MagnetSensor.withSensorDirection(
-            config.getExternalEncoderInverted() ? SensorDirectionValue.Clockwise_Positive
-                                                : SensorDirectionValue.CounterClockwise_Positive);
+        config.getExternalEncoderInverted().ifPresent(inverted -> {
+          cfg.MagnetSensor.withSensorDirection(
+              inverted ? SensorDirectionValue.Clockwise_Positive
+                       : SensorDirectionValue.CounterClockwise_Positive);
+        });
 
         // Configure feedback source for CANCoder
         m_talonConfig.ExternalFeedback.ExternalFeedbackSensorSource = ExternalFeedbackSensorSourceValue.FusedCANcoder;
@@ -866,7 +880,7 @@ public class TalonFXSWrapper extends SmartMotorController
         }
         if (useCANdiPWM1())
         {
-          cfg.PWM1.SensorDirection = config.getExternalEncoderInverted();
+          config.getExternalEncoderInverted().ifPresent(cfg.PWM1::withSensorDirection);
 
           // Zero offset
           if (config.getZeroOffset().isPresent())
@@ -882,7 +896,7 @@ public class TalonFXSWrapper extends SmartMotorController
           }
         } else if (useCANdiPWM2())
         {
-          cfg.PWM2.SensorDirection = config.getExternalEncoderInverted();
+          config.getExternalEncoderInverted().ifPresent(cfg.PWM2::withSensorDirection);
           // Zero offset
           if (config.getZeroOffset().isPresent())
           {
@@ -899,14 +913,14 @@ public class TalonFXSWrapper extends SmartMotorController
       }
     } else
     {
-      if (config.getExternalEncoderInverted())
+      if (config.getExternalEncoderInverted().isPresent())
       {
         throw new SmartMotorControllerConfigurationException("External Encoder cannot be inverted if not present!",
                                                              "External encoder is not inverted!",
                                                              "withExternalEncoderInverted(false)");
       }
 
-      if (config.getExternalEncoderGearing().getMechanismToRotorRatio() != 1.0)
+      if (config.getExternalEncoderGearing().isPresent())
       {
         throw new SmartMotorControllerConfigurationException("External Encoder cannot be set if not present!",
                                                              "External encoder gearing is not 1.0!",
@@ -949,10 +963,10 @@ public class TalonFXSWrapper extends SmartMotorController
     }
 
     // Invert the encoder.
-    if (config.getEncoderInverted())
+    if (config.getEncoderInverted().isPresent())
     {
       m_talonConfig.ExternalFeedback.withSensorPhase(
-          config.getEncoderInverted() ? SensorPhaseValue.Opposed : SensorPhaseValue.Aligned);
+          config.getEncoderInverted().get() ? SensorPhaseValue.Opposed : SensorPhaseValue.Aligned);
     }
 
     // Configure follower motors

--- a/yams/java/yams/motorcontrollers/remote/TalonFXWrapper.java
+++ b/yams/java/yams/motorcontrollers/remote/TalonFXWrapper.java
@@ -79,6 +79,7 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.function.Supplier;
 import yams.exceptions.SmartMotorControllerConfigurationException;
+import yams.gearing.MechanismGearing;
 import yams.motorcontrollers.SmartMotorController;
 import yams.motorcontrollers.SmartMotorControllerConfig;
 import yams.motorcontrollers.SmartMotorControllerConfig.ControlMode;
@@ -308,9 +309,11 @@ public class TalonFXWrapper extends SmartMotorController
         var cancoderSim = m_cancoder.get().getSimState();
         cancoderSim.setSupplyVoltage(m_simSupplier.get().getMechanismSupplyVoltage());
         cancoderSim.setVelocity(m_simSupplier.get().getMechanismVelocity()
-                                             .times(m_config.getExternalEncoderGearing().getMechanismToRotorRatio()));
+                                             .times(m_config.getExternalEncoderGearing().orElse(MechanismGearing.kOne)
+                                                            .getMechanismToRotorRatio()));
         cancoderSim.setRawPosition(m_simSupplier.get().getMechanismPosition()
                                                 .times(m_config.getExternalEncoderGearing()
+                                                               .orElse(MechanismGearing.kOne)
                                                                .getMechanismToRotorRatio()));
         cancoderSim.setMagnetHealth(MagnetHealthValue.Magnet_Green);
       }
@@ -323,18 +326,22 @@ public class TalonFXWrapper extends SmartMotorController
           candiSim.setPwm1Connected(true);
           candiSim.setPwm1Position(m_simSupplier.get().getMechanismPosition()
                                                 .times(m_config.getExternalEncoderGearing()
+                                                               .orElse(MechanismGearing.kOne)
                                                                .getMechanismToRotorRatio()));
           candiSim.setPwm1Velocity(m_simSupplier.get().getMechanismVelocity()
                                                 .times(m_config.getExternalEncoderGearing()
+                                                               .orElse(MechanismGearing.kOne)
                                                                .getMechanismToRotorRatio()));
         } else if (useCANdiPWM2())
         {
           candiSim.setPwm2Connected(true);
           candiSim.setPwm2Position(m_simSupplier.get().getMechanismPosition()
                                                 .times(m_config.getExternalEncoderGearing()
+                                                               .orElse(MechanismGearing.kOne)
                                                                .getMechanismToRotorRatio()));
           candiSim.setPwm2Velocity(m_simSupplier.get().getMechanismVelocity()
                                                 .times(m_config.getExternalEncoderGearing()
+                                                               .orElse(MechanismGearing.kOne)
                                                                .getMechanismToRotorRatio()));
         }
       }
@@ -731,8 +738,10 @@ public class TalonFXWrapper extends SmartMotorController
     }
 
     // Motor inversion
-    m_talonConfig.MotorOutput.Inverted = config.getMotorInverted() ? InvertedValue.Clockwise_Positive
-                                                                   : InvertedValue.CounterClockwise_Positive;
+    config.getMotorInverted().ifPresent(inverted -> {
+      m_talonConfig.MotorOutput.Inverted =
+          inverted ? InvertedValue.Clockwise_Positive : InvertedValue.CounterClockwise_Positive;
+    });
     // Idle mode
     if (config.getIdleMode().isPresent())
     {
@@ -746,12 +755,16 @@ public class TalonFXWrapper extends SmartMotorController
       m_talonConfig.Voltage.withPeakReverseVoltage(config.getClosedLoopControllerMaximumVoltage().get().times(-1));
     }
     // Ramp rates
-    m_talonConfig.ClosedLoopRamps.withDutyCycleClosedLoopRampPeriod(config.getClosedLoopRampRate());
-    m_talonConfig.OpenLoopRamps.withDutyCycleOpenLoopRampPeriod(config.getOpenLoopRampRate());
-    m_talonConfig.ClosedLoopRamps.withVoltageClosedLoopRampPeriod(config.getClosedLoopRampRate());
-    m_talonConfig.OpenLoopRamps.withVoltageOpenLoopRampPeriod(config.getOpenLoopRampRate());
-    m_talonConfig.ClosedLoopRamps.withTorqueClosedLoopRampPeriod(config.getClosedLoopRampRate());
-    m_talonConfig.OpenLoopRamps.withTorqueOpenLoopRampPeriod(config.getOpenLoopRampRate());
+    config.getClosedLoopRampRate().ifPresent(rampRate -> {
+      m_talonConfig.ClosedLoopRamps.withDutyCycleClosedLoopRampPeriod(rampRate)
+                                   .withVoltageClosedLoopRampPeriod(rampRate)
+                                   .withTorqueClosedLoopRampPeriod(rampRate);
+    });
+    config.getOpenLoopRampRate().ifPresent(rampRate -> {
+      m_talonConfig.OpenLoopRamps.withDutyCycleOpenLoopRampPeriod(rampRate)
+                                 .withVoltageOpenLoopRampPeriod(rampRate)
+                                 .withTorqueOpenLoopRampPeriod(rampRate);
+    });
     // Current limits
     if (config.getStatorStallCurrentLimit().isPresent())
     {
@@ -791,10 +804,10 @@ public class TalonFXWrapper extends SmartMotorController
       }
       // Set the gear ratio for external encoders.
       m_talonConfig.Feedback.RotorToSensorRatio = config.getGearing().getMechanismToRotorRatio() *
-                                                  config.getExternalEncoderGearing()
+                                                  config.getExternalEncoderGearing().orElse(MechanismGearing.kOne)
                                                         .getRotorToMechanismRatio();
       // config.getExternalEncoderGearing().getMechanismToRotorRatio() *
-      m_talonConfig.Feedback.SensorToMechanismRatio = config.getExternalEncoderGearing()
+      m_talonConfig.Feedback.SensorToMechanismRatio = config.getExternalEncoderGearing().orElse(MechanismGearing.kOne)
                                                             .getMechanismToRotorRatio();
       if (config.getExternalEncoder().get() instanceof CANcoder encoder)
       {
@@ -803,9 +816,11 @@ public class TalonFXWrapper extends SmartMotorController
         var cfg          = new CANcoderConfiguration();
         configurator.refresh(cfg);
         m_talonConfig.Feedback.FeedbackRemoteSensorID = encoder.getDeviceID();
-        cfg.MagnetSensor.withSensorDirection(
-            config.getExternalEncoderInverted() ? SensorDirectionValue.Clockwise_Positive
-                                                : SensorDirectionValue.CounterClockwise_Positive);
+        config.getExternalEncoderInverted().ifPresent(inversion -> {
+          cfg.MagnetSensor.withSensorDirection(
+              inversion ? SensorDirectionValue.Clockwise_Positive
+                        : SensorDirectionValue.CounterClockwise_Positive);
+        });
 
         // Configure feedback source for CANCoder
         m_talonConfig.Feedback.FeedbackSensorSource = FeedbackSensorSourceValue.FusedCANcoder;
@@ -839,7 +854,7 @@ public class TalonFXWrapper extends SmartMotorController
         }
         if (useCANdiPWM1())
         {
-          cfg.PWM1.SensorDirection = config.getExternalEncoderInverted();
+          config.getExternalEncoderInverted().ifPresent(cfg.PWM1::withSensorDirection);
 
           // Zero offset
           if (config.getZeroOffset().isPresent())
@@ -855,7 +870,7 @@ public class TalonFXWrapper extends SmartMotorController
           }
         } else if (useCANdiPWM2())
         {
-          cfg.PWM2.SensorDirection = config.getExternalEncoderInverted();
+          config.getExternalEncoderInverted().ifPresent(cfg.PWM2::withSensorDirection);
           // Zero offset
           if (config.getZeroOffset().isPresent())
           {
@@ -873,14 +888,14 @@ public class TalonFXWrapper extends SmartMotorController
 
     } else
     {
-      if (config.getExternalEncoderInverted())
+      if (config.getExternalEncoderInverted().isPresent())
       {
         throw new SmartMotorControllerConfigurationException("External Encoder cannot be inverted if not present!",
                                                              "External encoder is not inverted!",
                                                              "withExternalEncoderInverted(false)");
       }
 
-      if (config.getExternalEncoderGearing().getMechanismToRotorRatio() != 1.0)
+      if (config.getExternalEncoderGearing().isPresent())
       {
         throw new SmartMotorControllerConfigurationException("External Encoder cannot be set if not present!",
                                                              "External encoder gearing is not 1.0!",
@@ -933,7 +948,7 @@ public class TalonFXWrapper extends SmartMotorController
     }
 
     // Invert the encoder.
-    if (config.getEncoderInverted())
+    if (config.getEncoderInverted().isPresent())
     {
       throw new SmartMotorControllerConfigurationException("Integrated encoder phase cannot be set",
                                                            "Cannot configure TalonFX!",

--- a/yams/java/yams/telemetry/SmartMotorControllerTelemetryConfig.java
+++ b/yams/java/yams/telemetry/SmartMotorControllerTelemetryConfig.java
@@ -331,8 +331,20 @@ public class SmartMotorControllerTelemetryConfig
     {
       boolFields.get(BooleanTelemetryField.SimpleMotorFeedForward).disable();
     }
-    boolFields.get(BooleanTelemetryField.MotorInversion).setDefaultValue(config.getMotorInverted());
-    boolFields.get(BooleanTelemetryField.EncoderInversion).setDefaultValue(config.getEncoderInverted());
+    if (config.getMotorInverted().isPresent())
+    {
+      boolFields.get(BooleanTelemetryField.MotorInversion).setDefaultValue(config.getMotorInverted().get());
+    } else
+    {
+      boolFields.get(BooleanTelemetryField.MotorInversion).disable();
+    }
+    if (config.getEncoderInverted().isPresent())
+    {
+      boolFields.get(BooleanTelemetryField.EncoderInversion).setDefaultValue(config.getEncoderInverted().get());
+    } else
+    {
+      boolFields.get(BooleanTelemetryField.EncoderInversion).disable();
+    }
     return boolFields;
   }
 


### PR DESCRIPTION
Adds SimStartingPosition to Elevator, Pivot, and Arms.
Enforces that the ONLY config option which is ever always applied is the gearing. Everything else is completely optional.