### PR TITLE
Feedfoward, and SMC Config fixes

### DIFF
--- a/vendordep/src/test/java/yams/mechs/ShooterTest.java
+++ b/vendordep/src/test/java/yams/mechs/ShooterTest.java
@@ -104,7 +104,7 @@ public class ShooterTest
     ArrayList<Arguments> smcList = new ArrayList<>();
     offset += 1;
 
-    for (int i = 0; i < 3; i++)
+    for (int i = 0; i < 4; i++)
     {
       var smcConfig = createSMCConfig();
       switch (i)
@@ -114,6 +114,7 @@ public class ShooterTest
           break;
         case 2: smcConfig = addExponentialProfile(smcConfig);
           break;
+        case 3: smcConfig.withClosedLoopController(0,0,0);
       }
       SparkMax  smax  = new SparkMax(10 + offset + i, MotorType.kBrushless);
       SparkFlex sflex = new SparkFlex(20 + offset + i, MotorType.kBrushless);

--- a/yams/java/yams/motorcontrollers/SmartMotorControllerConfig.java
+++ b/yams/java/yams/motorcontrollers/SmartMotorControllerConfig.java
@@ -449,6 +449,7 @@ public class SmartMotorControllerConfig
    *
    * @param externalEncoderInverted External encoder inversion state.
    * @return {@link SmartMotorControllerConfig} for chaining.
+   * @implNote This may mean the zero offset you gather should be negated.
    */
   public SmartMotorControllerConfig withExternalEncoderInverted(boolean externalEncoderInverted)
   {
@@ -622,8 +623,7 @@ public class SmartMotorControllerConfig
                                                            "Cannot set zero offset.",
                                                            "withMechanismCircumference(Distance)");
     }
-    zeroOffset = Optional.ofNullable(convertToMechanism(distance));
-    return this;
+    return withExternalEncoderZeroOffset(convertToMechanism(distance));
   }
 
   /**
@@ -634,6 +634,11 @@ public class SmartMotorControllerConfig
    */
   public SmartMotorControllerConfig withExternalEncoderZeroOffset(Angle angle)
   {
+    if (angle != null && angle.lt(Rotations.of(0)))
+    {
+      // Zero offsets cannot be negative.
+      angle = angle.plus(Rotations.of(1));
+    }
     zeroOffset = Optional.ofNullable(angle);
     return this;
   }
@@ -1651,8 +1656,8 @@ public class SmartMotorControllerConfig
    * @param maxJerk         Maximum linear jerk for the Trapezoidal profile.
    * @return {@link SmartMotorControllerConfig} for chaining.
    * @implNote This overrides existing trapezoidal profiles with the last one given in the chain!
-   * @deprecated Please use {@link #withTrapezoidalProfile(LinearAcceleration, Velocity<LinearAccelerationUnit>)} to define
-   * your trapezoidal profile.
+   * @deprecated Please use {@link #withTrapezoidalProfile(LinearAcceleration, Velocity<LinearAccelerationUnit>)} to
+   * define your trapezoidal profile.
    */
   @Deprecated(since = "2026", forRemoval = true)
   public SmartMotorControllerConfig withSimClosedLoopController(double kP, double kI, double kD,

--- a/yams/java/yams/motorcontrollers/SmartMotorControllerConfig.java
+++ b/yams/java/yams/motorcontrollers/SmartMotorControllerConfig.java
@@ -2351,7 +2351,7 @@ public class SmartMotorControllerConfig
     {
       this.armFeedforward.remove(slot);
       this.elevatorFeedforward.remove(slot);
-      this.simpleFeedforward.remove(slot);
+      this.simpleFeedforward.put(slot, simpleFeedforward);
     }
     return this;
   }

--- a/yams/java/yams/motorcontrollers/remote/TalonFXWrapper.java
+++ b/yams/java/yams/motorcontrollers/remote/TalonFXWrapper.java
@@ -833,7 +833,6 @@ public class TalonFXWrapper extends SmartMotorController
           case SLOT_2 -> m_talonConfig.Slot2.withKS(kS).withKV(kV).withKA(kA).withKG(kG);
         }
       }
-      m_looseFollowers.ifPresent(smcs -> {for (var f : smcs) {f.setClosedLoopSlot(closedLoopControlSlot);}});
     }
 
     // Motor inversion


### PR DESCRIPTION
* TalonFX no longer unnecessarily sets the closed loop controller slot of all loosely coupled motors.
* Feedforwards are now set correctly.
* Negative zero offsets are allowed and external encoder inversions have a warning.
* Added feedforward only shooter unit test to prevent this from happening again.