### PR TITLE
Fix PivotTest, add SparkAbsoluteEncoder validation and tests

### DIFF
--- a/vendordep/src/test/java/yams/mechs/PivotTest.java
+++ b/vendordep/src/test/java/yams/mechs/PivotTest.java
@@ -66,15 +66,15 @@ public class PivotTest
         .withStatorCurrentLimit(Amps.of(40))
         .withMotorInverted(false)
         .withFeedforward(new SimpleMotorFeedforward(1, 0, 0, 0.02))
-        .withControlMode(ControlMode.CLOSED_LOOP);
+        .withControlMode(ControlMode.CLOSED_LOOP)
+        .withStartingPosition(Degrees.of(0))
+        .withMomentOfInertia(Inches.of(4), Pounds.of(1));
   }
 
   private static Pivot createPivot(SmartMotorController smc)
   {
     PivotConfig config = new PivotConfig(smc)
-        .withHardLimits(Degrees.of(-100), Degrees.of(150))
-        .withStartingPosition(Degrees.of(0))
-        .withMOI(Inches.of(4), Pounds.of(1));
+        .withHardLimits(Degrees.of(-100), Degrees.of(150));
     Pivot                             pivot  = new Pivot(config);
     SmartMotorControllerTestSubsystem subsys = (SmartMotorControllerTestSubsystem) smc.getConfig().getSubsystem();
     subsys.smc = smc;

--- a/vendordep/src/test/java/yams/motorcontrollers/SparkAbsoluteEncoderTest.java
+++ b/vendordep/src/test/java/yams/motorcontrollers/SparkAbsoluteEncoderTest.java
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Yet Another Software Suite
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package yams.motorcontrollers;
+
+import static edu.wpi.first.units.Units.Rotations;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.revrobotics.spark.SparkLowLevel.MotorType;
+import com.revrobotics.spark.SparkMax;
+import edu.wpi.first.math.system.plant.DCMotor;
+import edu.wpi.first.wpilibj.Preferences;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import yams.exceptions.SmartMotorControllerConfigurationException;
+import yams.gearing.GearBox;
+import yams.gearing.MechanismGearing;
+import yams.helpers.MockHardwareExtension;
+import yams.helpers.SmartMotorControllerTestSubsystem;
+import yams.motorcontrollers.local.SparkWrapper;
+
+public class SparkAbsoluteEncoderTest
+{
+  private static SmartMotorControllerConfig baseConfig()
+  {
+    return new SmartMotorControllerConfig()
+        .withSubsystem(new SmartMotorControllerTestSubsystem())
+        .withGearing(new MechanismGearing(GearBox.fromReductionStages(1)));
+  }
+
+  @BeforeEach
+  void startTest()
+  {
+    MockHardwareExtension.beforeAll();
+  }
+
+  @AfterEach
+  void endTest()
+  {
+    MockHardwareExtension.afterAll();
+    Preferences.removeAll();
+  }
+
+  @Test
+  void testZeroCenteredTrueWith0_5DiscontinuityPoint()
+  {
+    SparkMax sparkMax = new SparkMax(90, MotorType.kBrushless);
+    SmartMotorControllerConfig config = baseConfig()
+        .withExternalEncoder(sparkMax.getAbsoluteEncoder())
+        .withExternalEncoderDiscontinuityPoint(Rotations.of(0.5));
+    assertDoesNotThrow(() -> new SparkWrapper(sparkMax, DCMotor.getNEO(1), config));
+    sparkMax.close();
+  }
+
+  @Test
+  void testZeroCenteredFalseWith1_0DiscontinuityPoint()
+  {
+    SparkMax sparkMax = new SparkMax(91, MotorType.kBrushless);
+    SmartMotorControllerConfig config = baseConfig()
+        .withExternalEncoder(sparkMax.getAbsoluteEncoder())
+        .withExternalEncoderDiscontinuityPoint(Rotations.of(1));
+    assertDoesNotThrow(() -> new SparkWrapper(sparkMax, DCMotor.getNEO(1), config));
+    sparkMax.close();
+  }
+
+  @Test
+  void testExceptionWhenAbsoluteEncoderWithoutDiscontinuityPoint()
+  {
+    SparkMax sparkMax = new SparkMax(92, MotorType.kBrushless);
+    SmartMotorControllerConfig config = baseConfig()
+        .withExternalEncoder(sparkMax.getAbsoluteEncoder());
+    assertThrows(SmartMotorControllerConfigurationException.class,
+                 () -> new SparkWrapper(sparkMax, DCMotor.getNEO(1), config));
+    sparkMax.close();
+  }
+
+  @Test
+  void testExceptionWhenDiscontinuityPointWithoutEncoder()
+  {
+    SparkMax sparkMax = new SparkMax(93, MotorType.kBrushless);
+    SmartMotorControllerConfig config = baseConfig()
+        .withExternalEncoderDiscontinuityPoint(Rotations.of(0.5));
+    assertThrows(SmartMotorControllerConfigurationException.class,
+                 () -> new SparkWrapper(sparkMax, DCMotor.getNEO(1), config));
+    sparkMax.close();
+  }
+}

--- a/yams/java/yams/mechanisms/config/PivotConfig.java
+++ b/yams/java/yams/mechanisms/config/PivotConfig.java
@@ -342,6 +342,10 @@ public class PivotConfig
     {
       return moi.getAsDouble();
     }
+    if (motor.isPresent() && motor.get().getConfig().isMoiExplicitlySet())
+    {
+      return motor.get().getConfig().getMOI();
+    }
     throw new PivotConfigurationException("Pivot MOI must be set!",
                                           "Cannot get the MOI!",
                                           "withLength(Distance).withMass(Mass) OR PivotConfig.withMOI()");

--- a/yams/java/yams/mechanisms/config/SwerveModuleConfig.java
+++ b/yams/java/yams/mechanisms/config/SwerveModuleConfig.java
@@ -293,6 +293,27 @@ public class SwerveModuleConfig
   }
 
   /**
+   * Set the discontinuity point for the absolute encoder on the azimuth {@link SmartMotorController}.
+   * Required when using a {@link com.revrobotics.spark.SparkAbsoluteEncoder} so that the zeroCentered
+   * mode can be determined. Use {@link edu.wpi.first.units.Units#Rotations Rotations.of(0.5)} for
+   * zero-centered output (-0.5 to 0.5), or {@link edu.wpi.first.units.Units#Rotations Rotations.of(1)}
+   * for unsigned output (0 to 1).
+   *
+   * @param discontinuityPoint Discontinuity point for the absolute encoder (must be 0.5 or 1 rotations).
+   * @return {@link SwerveModuleConfig} for chaining.
+   */
+  public SwerveModuleConfig withAbsoluteEncoderDiscontinuityPoint(Angle discontinuityPoint)
+  {
+    if (azimuthMotor.isPresent())
+    {
+      SmartMotorControllerConfig azimuthConfig = azimuthMotor.orElseThrow().getConfig();
+      if (azimuthConfig.getExternalEncoder().isPresent())
+      {azimuthConfig.withExternalEncoderDiscontinuityPoint(discontinuityPoint);}
+    }
+    return this;
+  }
+
+  /**
    * Set the wheel radius for the {@link SmartMotorController}, ideally should be set inside the drive motor
    * {@link SmartMotorControllerConfig}
    *

--- a/yams/java/yams/motorcontrollers/SmartMotorControllerConfig.java
+++ b/yams/java/yams/motorcontrollers/SmartMotorControllerConfig.java
@@ -296,6 +296,10 @@ public class SmartMotorControllerConfig
   private       MomentOfInertia                                           moi                                = KilogramSquareMeters.of(
       0.02);
   /**
+   * Whether the moment of inertia was explicitly set by the user (vs. the default 0.02 kg*m^2).
+   */
+  private       boolean                                                   moiExplicitlySet                   = false;
+  /**
    * Loosely coupled followers.
    */
   private       Optional<SmartMotorController[]>                          looselyCoupledFollowers            = Optional.empty();
@@ -389,6 +393,7 @@ public class SmartMotorControllerConfig
     this.minContinuousWrappingAngle = cfg.minContinuousWrappingAngle;
     this.closedLoopTolerance = cfg.closedLoopTolerance;
     this.moi = cfg.moi;
+    this.moiExplicitlySet = cfg.moiExplicitlySet;
     this.looselyCoupledFollowers = cfg.looselyCoupledFollowers;
     this.linearClosedLoopController = cfg.linearClosedLoopController;
     this.velocityTrapezoidalProfile = cfg.velocityTrapezoidalProfile;
@@ -882,6 +887,7 @@ public class SmartMotorControllerConfig
     } else
     {
       moi = KilogramSquareMeters.of(SingleJointedArmSim.estimateMOI(length.in(Meters), weight.in(Kilograms)));
+      moiExplicitlySet = true;
     }
     return this;
   }
@@ -898,6 +904,7 @@ public class SmartMotorControllerConfig
   public SmartMotorControllerConfig withMomentOfInertia(double MOI)
   {
     moi = KilogramSquareMeters.of(MOI);
+    moiExplicitlySet = true;
     return this;
   }
 
@@ -911,7 +918,18 @@ public class SmartMotorControllerConfig
   public SmartMotorControllerConfig withMomentOfInertia(MomentOfInertia MOI)
   {
     moi = MOI;
+    moiExplicitlySet = true;
     return this;
+  }
+
+  /**
+   * Check if the moment of inertia was explicitly set by the user.
+   *
+   * @return {@code true} if {@link #withMomentOfInertia} was called, {@code false} if using the default.
+   */
+  public boolean isMoiExplicitlySet()
+  {
+    return moiExplicitlySet;
   }
 
   /**
@@ -1862,6 +1880,7 @@ public class SmartMotorControllerConfig
   public SmartMotorControllerConfig withExponentialProfile(Voltage maxVolts, DCMotor motor, MomentOfInertia moi)
   {
     this.moi = moi;
+    this.moiExplicitlySet = true;
     var sysid = LinearSystemId.createSingleJointedArmSystem(motor,
                                                             moi.in(KilogramSquareMeters),
                                                             gearing.getMechanismToRotorRatio());

--- a/yams/java/yams/motorcontrollers/local/SparkWrapper.java
+++ b/yams/java/yams/motorcontrollers/local/SparkWrapper.java
@@ -607,6 +607,13 @@ public class SparkWrapper extends SmartMotorController
           m_sparkBaseConfig.absoluteEncoder.zeroCentered(config.getExternalEncoderDiscontinuityPoint().get()
                                                                .isEquivalent(Rotations.of(0.5)));
         }
+        else
+        {
+          throw new SmartMotorControllerConfigurationException(
+              "SparkAbsoluteEncoder requires a discontinuity point to set zeroCentered correctly",
+              "zeroCentered state is ambiguous without a discontinuity point",
+              ".withExternalEncoderDiscontinuityPoint(Rotations.of(0.5)) or .withExternalEncoderDiscontinuityPoint(Rotations.of(1))");
+        }
 
         if (RobotBase.isSimulation())
         {


### PR DESCRIPTION
## Summary

- **Task 1 — PivotTest fix**: Moved `.withStartingPosition(Degrees.of(0))` and `.withMomentOfInertia(Inches.of(4), Pounds.of(1))` from the `PivotConfig` chain in `createPivot()` to the `SmartMotorControllerConfig` chain in `createSMCConfig()`. Updated `PivotConfig.getMOI()` to fall back to the motor's SMC config MOI (only when explicitly set, guarded by a new `isMoiExplicitlySet()` flag on `SmartMotorControllerConfig`).
- **Task 2 — SparkWrapper validation**: Added an `else` branch in `SparkWrapper.applyConfig()` that throws `SmartMotorControllerConfigurationException` when a `SparkAbsoluteEncoder` is configured without a discontinuity point (the `zeroCentered` mode would be ambiguous). Also added `withAbsoluteEncoderDiscontinuityPoint()` to `SwerveModuleConfig` so swerve users who pass a `SparkAbsoluteEncoder` as their azimuth encoder have a way to satisfy this requirement.
- **Task 3 — SparkAbsoluteEncoderTest**: Added four tests covering: valid `0.5` discontinuity point, valid `1.0` discontinuity point, exception when encoder is set without a discontinuity point, and exception when a discontinuity point is set without an encoder.

## Test plan

- [x] `./gradlew test` passes all 223 tests with no failures
- [x] `SparkAbsoluteEncoderTest` — all 4 new tests pass
- [x] `PivotTest` — all 26 tests pass (previously 12 failures due to missing MOI/starting position)
- [x] `ArmTest`, `ElevatorTest`, `ShooterTest`, `SmartMotorFactoryTest`, `ChineseRemainderTheoremTest` — all pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)