### PR TITLE
Fix TalonFX wrapper bug

### DIFF
--- a/yams/java/yams/motorcontrollers/remote/TalonFXWrapper.java
+++ b/yams/java/yams/motorcontrollers/remote/TalonFXWrapper.java
@@ -1108,7 +1108,7 @@ public class TalonFXWrapper extends SmartMotorController
 
           } else if (follower.getFirst() instanceof TalonFX)
           {
-            config.getIdleMode().ifPresent(mode -> ((TalonFXS) follower.getFirst()).setNeutralMode(mode == MotorMode.BRAKE ? NeutralModeValue.Brake : NeutralModeValue.Coast));
+            config.getIdleMode().ifPresent(mode -> ((TalonFX) follower.getFirst()).setNeutralMode(mode == MotorMode.BRAKE ? NeutralModeValue.Brake : NeutralModeValue.Coast));
             applied = ((TalonFX) follower.getFirst()).setControl(new Follower(m_talonfx.getDeviceID(),
                                                                               follower.getSecond()
                                                                               ? MotorAlignmentValue.Opposed


### PR DESCRIPTION
I simulated the code and saw this error I believe this fixes it. I could be very wrong though
Error at yams.motorcontrollers.remote.TalonFXWrapper.lambda$applyConfig$29(TalonFXWrapper.java:1111): Unhandled exception instantiating robot yams.motorcontrollers.remote.TalonFXWrapper java.lang.ClassCastException: class com.ctre.phoenix6.hardware.TalonFX cannot be cast to class com.ctre.phoenix6.hardware.TalonFXS (com.ctre.phoenix6.hardware.TalonFX and com.ctre.phoenix6.hardware.TalonFXS are in unnamed module of loader 'app')
        at yams.motorcontrollers.remote.TalonFXWrapper.lambda$applyConfig$29(TalonFXWrapper.java:1111)
        at java.base/java.util.Optional.ifPresent(Optional.java:178)
        at yams.motorcontrollers.remote.TalonFXWrapper.applyConfig(TalonFXWrapper.java:1111)
        at yams.motorcontrollers.remote.TalonFXWrapper.<init>(TalonFXWrapper.java:277)
        at igknighters.subsystems.YamShooter.flywheels.FlywheelsFunctioning.<init>(FlywheelsFunctioning.java:47)
        at igknighters.subsystems.YamShooter.Shooter.<init>(Shooter.java:38)
        at igknighters.Robot.<init>(Robot.java:241)
        at edu.wpi.first.wpilibj.RobotBase.runRobot(RobotBase.java:387)
        at edu.wpi.first.wpilibj.RobotBase.lambda$startRobot$1(RobotBase.java:507)
        at java.base/java.lang.Thread.run(Thread.java:840)
