### PR TITLE
Battery sim AND SwerveDrive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
         continue-on-error: true
 
   test-java:
-    name: Java unit tests
+    name: Java unit tests - ${{ matrix.group }}
     needs: [build-linux]
     runs-on: ubuntu-latest
     permissions:
@@ -128,6 +128,20 @@ jobs:
     defaults:
       run:
         working-directory: vendordep
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Mechanism-level integration tests (Arm/Elevator/Pivot/Shooter/Swerve/limits): these
+          # create the largest number of simulated motor controller devices per JVM.
+          - group: mechanisms
+            test-filter: '--tests "yams.mechs.*"'
+          # Motor controller / battery sim unit tests, plus the standalone math test: kept in
+          # their own JVM so they aren't run after the mechanisms group has already created
+          # hundreds of simulated devices in the same process — that accumulation was observed to
+          # make SimulationPeriodTest flaky.
+          - group: motorcontrollers
+            test-filter: '--tests "yams.motorcontrollers.*" --tests "yams.ChineseRemainderTheoremTest"'
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v4
@@ -155,8 +169,8 @@ jobs:
         with:
           name: maven-linux
           path: vendordep/build/maven/
-      - name: Java unit tests
-        run: ./gradlew test
+      - name: Java unit tests - ${{ matrix.group }}
+        run: ./gradlew test ${{ matrix.test-filter }}
 
   build-host:
     name: Build - ${{ matrix.artifact-name }}

--- a/examples/simple_robot/.idea/modules.xml
+++ b/examples/simple_robot/.idea/modules.xml
@@ -3,6 +3,7 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/simple_robot.main.iml" filepath="$PROJECT_DIR$/.idea/modules/simple_robot.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/simple_robot.test.iml" filepath="$PROJECT_DIR$/.idea/modules/simple_robot.test.iml" />
     </modules>
   </component>
 </project>

--- a/examples/simple_robot/build.gradle
+++ b/examples/simple_robot/build.gradle
@@ -16,7 +16,7 @@ sourceSets {
         java {
             srcDirs 'src/main/java'
             // YAMS_TESTING
-            srcDirs '../../../yams/java'
+            srcDirs '../../yams/java'
             // END_YAMS_TESTING
         }
     }

--- a/examples/simple_robot/build.gradle
+++ b/examples/simple_robot/build.gradle
@@ -16,7 +16,7 @@ sourceSets {
         java {
             srcDirs 'src/main/java'
             // YAMS_TESTING
-            srcDirs '../../yams/java'
+            srcDirs '../../../yams/java'
             // END_YAMS_TESTING
         }
     }

--- a/examples/simple_robot/simgui-ds.json
+++ b/examples/simple_robot/simgui-ds.json
@@ -1,4 +1,9 @@
 {
+  "Keyboard 0 Settings": {
+    "window": {
+      "visible": true
+    }
+  },
   "keyboardJoysticks": [
     {
       "axisConfig": [
@@ -11,13 +16,16 @@
           "incKey": 83
         },
         {
-          "decKey": 69,
           "decayRate": 0.0,
-          "incKey": 82,
           "keyRate": 0.009999999776482582
+        },
+        {},
+        {
+          "decKey": 82,
+          "incKey": 69
         }
       ],
-      "axisCount": 3,
+      "axisCount": 5,
       "buttonCount": 7,
       "buttonKeys": [
         90,

--- a/examples/simple_robot/src/main/java/frc/robot/RobotContainer.java
+++ b/examples/simple_robot/src/main/java/frc/robot/RobotContainer.java
@@ -6,92 +6,48 @@
 
 package frc.robot;
 
+import static edu.wpi.first.units.Units.Degrees;
+import static edu.wpi.first.units.Units.Meters;
+import static edu.wpi.first.units.Units.RPM;
+
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
-import frc.robot.subsystems.TurretSubsystem;
+import frc.robot.subsystems.ArmSubsystem;
+import frc.robot.subsystems.ElevatorSubsystem;
+import frc.robot.subsystems.ShooterSubsystem;
+import frc.robot.subsystems.SwerveSubsystem;
 
 public class RobotContainer
 {
-  //  private final ArmSubsystem arm = new ArmSubsystem();
-//  private final DoubleFlyWheelSubsystem flyWheelSubsystem = new DoubleFlyWheelSubsystem();
-//  private final DiffyMechSubsystem m_diffyMechSubsystem = new DiffyMechSubsystem();
-//  private final DoubleJointedArmSubsystem jointedArm = new DoubleJointedArmSubsystem();
-//  private final ElevatorSubsystem elevator = new ElevatorSubsystem();
-//private final SwerveSubsystem drive = new SwerveSubsystem();
-//  private final ShooterSubsystem shooter = new ShooterSubsystem();
-  private final TurretSubsystem turret = new TurretSubsystem();
+  private final SwerveSubsystem   drive    = new SwerveSubsystem();
+  private final ArmSubsystem      arm      = new ArmSubsystem();
+  private final ElevatorSubsystem elevator = new ElevatorSubsystem();
+  private final ShooterSubsystem  shooter  = new ShooterSubsystem();
 
-  private final CommandXboxController     xboxController = new CommandXboxController(0);
+  private final CommandXboxController xboxController = new CommandXboxController(0);
 
   public RobotContainer()
   {
     DriverStation.silenceJoystickConnectionWarning(true);
-//    flyWheelSubsystem.setDefaultCommand(flyWheelSubsystem.setDutyCycle(0, 0));
-//    arm.setDefaultCommand(arm.armCmd(0));
-//    arm.setDefaultCommand(arm.setAngle(Degrees.of(0)));
-//    jointedArm.setDefaultCommand(jointedArm.setAngle(Degrees.of(90), Degrees.of(0)));
-//    elevator.setDefaultCommand(elevator.elevCmd(0));
-//    turret.setDefaultCommand(turret.turretCmd(0.0));
-//    drive.setDefaultCommand(drive.setRobotRelativeChassisSpeeds(new ChassisSpeeds()));
+    drive.setDefaultCommand(drive.driveWithJoystick(xboxController));
+    arm.setDefaultCommand(arm.setAngle(Degrees.of(0)));
+    elevator.setDefaultCommand(elevator.setHeight(Meters.of(0)));
+    shooter.setDefaultCommand(shooter.setVelocity(RPM.of(0)));
     configureBindings();
   }
 
   private void configureBindings()
   {
-//    xboxController.button(1).whileTrue(shooter.setVelocity(RPM.of(1000)));
-//    xboxController.button(2).whileTrue(shooter.setVelocity(RPM.of(-1000)));
-//    xboxController.button(3).whileTrue(shooter.set(0));
-//    xboxController.button(4).whileTrue(shooter.set(0.5));
+    xboxController.button(1).whileTrue(arm.setAngle(Degrees.of(30)));
+    xboxController.button(2).whileTrue(arm.setAngle(Degrees.of(80)));
 
-//    xboxController.button(1).whileTrue(drive.setRobotRelativeChassisSpeeds(new ChassisSpeeds(0.5, 0, 0)));
-//    xboxController.button(2).whileTrue(drive.setRobotRelativeChassisSpeeds(new ChassisSpeeds(-0.5, 0, 0)));
-//    xboxController.button(3).whileTrue(drive.setRobotRelativeChassisSpeeds(new ChassisSpeeds(0, 0.5, 0)));
-//    xboxController.button(4).whileTrue(drive.setRobotRelativeChassisSpeeds(new ChassisSpeeds(0, -0.5, 0)));
-//    xboxController.button(5).whileTrue(drive.driveToPose(new Pose2d(Meters.of(3),
-//                                                                    Meters.of(3),
-//                                                                    Rotation2d.fromDegrees(30))));
-//    xboxController.button(6).whileTrue(drive.driveToPose(new Pose2d(Meters.of(5),
-//                                                                    Meters.of(6),
-//                                                                    Rotation2d.fromDegrees(70))));
-//
-    //    xboxController.button(1).whileTrue(m_diffyMechSubsystem.setAngle(Degrees.of(15), Degrees.of(15)));
-//    xboxController.button(2).whileTrue(m_diffyMechSubsystem.setAngle(Degrees.of(30), Degrees.of(45)));
-//    xboxController.button(3).whileTrue(m_diffyMechSubsystem.set(0,0));
-//    xboxController.button(4).whileTrue(m_diffyMechSubsystem.set(0.5,0));
-//    xboxController.button(5).whileTrue(m_diffyMechSubsystem.set(0,0.5));
+    xboxController.button(3).whileTrue(elevator.setHeight(Meters.of(0.5)));
+    xboxController.button(4).whileTrue(elevator.setHeight(Meters.of(1.5)));
 
-//    xboxController.button(1).whileTrue(jointedArm.setPosition(Meters.of(0.5), Meters.of(0.5), false));
-//    xboxController.button(2).whileTrue(jointedArm.setPosition(Meters.of(0.5), Meters.of(0.5), true));
-
-//    xboxController.button(1).whileTrue(elevator.setHeight(Meters.of(1)));
-//    xboxController.button(2).whileTrue(elevator.setHeight(Meters.of(0)));
-//    xboxController.button(3).whileTrue(elevator.sysId());
-//    xboxController.button(4).whileTrue(elevator.elevCmd(-0.5));
-//    xboxController.button(5).whileTrue(elevator.elevCmd(0.5));
-
-//    xboxController.button(1).whileTrue(jointedArm.setAngle(Degrees.of(90), null));
-//    xboxController.button(2).whileTrue(jointedArm.set(null, 1.0));
-//    xboxController.button(3).whileTrue(jointedArm.setAngle(Degrees.of(15), Degrees.of(45)));
-//    xboxController.button(4).whileTrue(jointedArm.setAngle(Degrees.of(180), Degrees.of(90)));
-//    xboxController.button(5).whileTrue(jointedArm.setAngle(Degrees.of(135), Degrees.of(135)));
-//
-//    xboxController.button(1).whileTrue(arm.armCmd(0.5));
-//    xboxController.button(2).whileTrue(arm.armCmd(-0.5));
-//    xboxController.button(3).whileTrue(arm.setAngle(Degrees.of(30)));
-//    xboxController.button(4).whileTrue(arm.setAngle(Degrees.of(80)));
-
-//    xboxController.button(1).whileTrue(flyWheelSubsystem.setDutyCycle(0, 0.5));
-//    xboxController.button(2).whileTrue(flyWheelSubsystem.setDutyCycle(0.5, 0));
-//    xboxController.button(3).whileTrue(flyWheelSubsystem.setVelocity(RPM.of(3000), RPM.of(6000)));
-//    xboxController.button(1).whileTrue(arm.setAngle(Degrees.of(-30)));
-//    xboxController.button(2).whileTrue(arm.setAngle(Degrees.of(30)));
-//    xboxController.button(3).whileTrue(arm.sysId());
-
-//    xboxController.button(1).whileTrue(turret.turretCmd(0.2));
-//    xboxController.button(2).whileTrue(turret.turretCmd(-0.2));
-//    xboxController.button(3).whileTrue(turret.sysId());
+    xboxController.button(5).whileTrue(shooter.setVelocity(RPM.of(3500)));
+    xboxController.button(6).whileTrue(shooter.setVelocity(RPM.of(2000)));
   }
 
   public Command getAutonomousCommand()

--- a/examples/simple_robot/src/main/java/frc/robot/subsystems/ArmSubsystem.java
+++ b/examples/simple_robot/src/main/java/frc/robot/subsystems/ArmSubsystem.java
@@ -36,7 +36,7 @@ import yams.motorcontrollers.simulation.Sensor;
 
 public class ArmSubsystem extends SubsystemBase {
   private final CANcoder cancoder = new CANcoder(2);
-  private final TalonFX armMotor = new TalonFX(1);
+  private final TalonFX armMotor = new TalonFX(15);
   //  private final SmartMotorControllerTelemetryConfig motorTelemetryConfig = new
   //  SmartMotorControllerTelemetryConfig()
   //          .withMechanismPosition()

--- a/examples/simple_robot/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
+++ b/examples/simple_robot/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
@@ -41,7 +41,7 @@ public class ElevatorSubsystem extends SubsystemBase {
   private final Mass weight = Pounds.of(16);
   private final DCMotor motors = DCMotor.getNEO(1);
   private final MechanismGearing gearing = new MechanismGearing(GearBox.fromReductionStages(3, 4));
-  private final SparkMax elevatorMotor = new SparkMax(2, SparkLowLevel.MotorType.kBrushless);
+  private final SparkMax elevatorMotor = new SparkMax(13, SparkLowLevel.MotorType.kBrushless);
   //  private final SmartMotorControllerTelemetryConfig motorTelemetryConfig = new
   //  SmartMotorControllerTelemetryConfig()
   //          .withMechanismPosition()

--- a/examples/simple_robot/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
+++ b/examples/simple_robot/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
@@ -74,8 +74,8 @@ public class SwerveSubsystem extends SubsystemBase {
     return new SwerveModule(moduleConfig);
   }
 
+  private final Pigeon2 gyro = new Pigeon2(14);
   public SwerveSubsystem() {
-    Pigeon2 gyro = new Pigeon2(14);
     var fl =
         createModule(new SparkMax(1, MotorType.kBrushless), new SparkMax(2, MotorType.kBrushless),
             new CANcoder(3), "frontleft", new Translation2d(Inches.of(10), Inches.of(10)));
@@ -91,11 +91,12 @@ public class SwerveSubsystem extends SubsystemBase {
     SwerveDriveConfig config =
         new SwerveDriveConfig(this, fl, fr, bl, br)
             .withGyro(gyro.getYaw().asSupplier())
+            //.withGyroVelocity(gyro.getAngularVelocityZDevice().asSupplier())
+            //.withGyroAngularVelocityScaleFactor(1)
             .withMaximumChassisSpeed(MetersPerSecond.of(4), RotationsPerSecond.of(360))
             .withStartingPose(new Pose2d(0, 0, Rotation2d.fromDegrees(0)))
             .withTranslationController(new PIDController(1, 0, 0))
-            .withRotationController(new PIDController(1, 0, 0))
-            .withGyroAngularVelocityScaleFactor(0.3);
+            .withRotationController(new PIDController(1, 0, 0));
     drive = new SwerveDrive(config);
 
     SmartDashboard.putData("Field", field);
@@ -148,6 +149,7 @@ public class SwerveSubsystem extends SubsystemBase {
   @Override
   public void simulationPeriodic() {
     drive.simIterate();
+    gyro.getSimState().setRawYaw(drive.getSimPose().getRotation().getRadians());
   }
 
   public Pose2d getPose() {

--- a/examples/simple_robot/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
+++ b/examples/simple_robot/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
@@ -3,16 +3,19 @@
 
 package frc.robot.subsystems;
 
-
 import static edu.wpi.first.units.Units.Amps;
+import static edu.wpi.first.units.Units.DegreesPerSecond;
 import static edu.wpi.first.units.Units.Inches;
+import static edu.wpi.first.units.Units.MetersPerSecond;
 import static edu.wpi.first.units.Units.Radians;
+import static edu.wpi.first.units.Units.RotationsPerSecond;
 
 import com.ctre.phoenix6.hardware.CANcoder;
 import com.ctre.phoenix6.hardware.Pigeon2;
 import com.revrobotics.spark.SparkLowLevel.MotorType;
 import com.revrobotics.spark.SparkMax;
 import edu.wpi.first.math.controller.PIDController;
+import edu.wpi.first.math.controller.SimpleMotorFeedforward;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
@@ -23,128 +26,139 @@ import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import java.util.function.Supplier;
 import yams.gearing.GearBox;
 import yams.gearing.MechanismGearing;
+import yams.math.DerivativeTimeFilter;
 import yams.mechanisms.config.SwerveDriveConfig;
 import yams.mechanisms.config.SwerveModuleConfig;
 import yams.mechanisms.swerve.SwerveDrive;
 import yams.mechanisms.swerve.SwerveModule;
+import yams.mechanisms.swerve.utility.SwerveInputStream;
 import yams.motorcontrollers.SmartMotorController;
 import yams.motorcontrollers.SmartMotorControllerConfig;
 import yams.motorcontrollers.local.SparkWrapper;
 
-public class SwerveSubsystem extends SubsystemBase
-{
+public class SwerveSubsystem extends SubsystemBase {
   private final SwerveDrive drive;
-  private final Field2d     field = new Field2d();
+  private final Field2d field = new Field2d();
 
-  public SwerveModule createModule(SparkMax drive, SparkMax azimuth, CANcoder absoluteEncoder, String moduleName,
-                                   Translation2d location)
-  {
-    MechanismGearing driveGearing         = new MechanismGearing(GearBox.fromStages("12:1", "2:1"));
-    MechanismGearing azimuthGearing       = new MechanismGearing(GearBox.fromStages("21:1"));
-    PIDController    azimuthPIDController = new PIDController(1, 0, 0);
-    SmartMotorControllerConfig driveCfg = new SmartMotorControllerConfig(this)
-        .withWheelDiameter(Inches.of(4))
-        .withClosedLoopController(50, 0, 4)
-        .withGearing(driveGearing)
-        .withStatorCurrentLimit(Amps.of(40))
-        .withTelemetry("driveMotor", SmartMotorControllerConfig.TelemetryVerbosity.HIGH);
-    SmartMotorControllerConfig azimuthCfg = new SmartMotorControllerConfig(this)
-        .withClosedLoopController(50, 0, 4)
-        .withContinuousWrapping(Radians.of(-Math.PI), Radians.of(Math.PI))
-        .withGearing(azimuthGearing)
-        .withStatorCurrentLimit(Amps.of(20))
-        .withTelemetry("angleMotor", SmartMotorControllerConfig.TelemetryVerbosity.HIGH);
-    SmartMotorController driveSMC   = new SparkWrapper(drive, DCMotor.getNEO(1), driveCfg);
+  public SwerveModule createModule(SparkMax drive, SparkMax azimuth, CANcoder absoluteEncoder,
+      String moduleName, Translation2d location) {
+    MechanismGearing driveGearing = new MechanismGearing(GearBox.fromReductionStages(6.75));
+    MechanismGearing azimuthGearing = new MechanismGearing(GearBox.fromReductionStages(12.8));
+    SmartMotorControllerConfig driveCfg =
+        new SmartMotorControllerConfig(this)
+            .withWheelDiameter(Inches.of(4))
+            .withClosedLoopController(0.4, 0, 0)
+            //            .withFeedforward(new SimpleMotorFeedforward(0, 0.7, 0.1))
+            .withGearing(driveGearing)
+            .withStatorCurrentLimit(Amps.of(40))
+            .withTelemetry("driveMotor", SmartMotorControllerConfig.TelemetryVerbosity.HIGH);
+    SmartMotorControllerConfig azimuthCfg =
+        new SmartMotorControllerConfig(this)
+            .withClosedLoopController(3.8476, 0, 0)
+            .withContinuousWrapping(Radians.of(-Math.PI), Radians.of(Math.PI))
+            .withGearing(azimuthGearing)
+            .withStatorCurrentLimit(Amps.of(40))
+            .withTelemetry("angleMotor", SmartMotorControllerConfig.TelemetryVerbosity.HIGH);
+    SmartMotorController driveSMC = new SparkWrapper(drive, DCMotor.getNEO(1), driveCfg);
     SmartMotorController azimuthSMC = new SparkWrapper(azimuth, DCMotor.getNEO(1), azimuthCfg);
-    SwerveModuleConfig moduleConfig = new SwerveModuleConfig(driveSMC, azimuthSMC)
-        .withAbsoluteEncoder(absoluteEncoder.getAbsolutePosition().asSupplier())
-        .withTelemetry(moduleName, SmartMotorControllerConfig.TelemetryVerbosity.HIGH)
-        .withLocation(location)
-        .withOptimization(true);
+    SwerveModuleConfig moduleConfig =
+        new SwerveModuleConfig(driveSMC, azimuthSMC)
+            .withAbsoluteEncoder(absoluteEncoder.getAbsolutePosition().asSupplier())
+            .withTelemetry(moduleName, SmartMotorControllerConfig.TelemetryVerbosity.HIGH)
+            .withLocation(location)
+            .withOptimization(true);
     return new SwerveModule(moduleConfig);
   }
 
-  public SwerveSubsystem()
-  {
+  public SwerveSubsystem() {
     Pigeon2 gyro = new Pigeon2(14);
-    var fl = createModule(new SparkMax(1, MotorType.kBrushless),
-                          new SparkMax(2, MotorType.kBrushless),
-                          new CANcoder(3),
-                          "frontleft",
-                          new Translation2d(Inches.of(24), Inches.of(24)));
-    var fr = createModule(new SparkMax(4, MotorType.kBrushless),
-                          new SparkMax(5, MotorType.kBrushless),
-                          new CANcoder(6),
-                          "frontright",
-                          new Translation2d(Inches.of(24), Inches.of(-24)));
-    var bl = createModule(new SparkMax(7, MotorType.kBrushless),
-                          new SparkMax(8, MotorType.kBrushless),
-                          new CANcoder(9),
-                          "backleft",
-                          new Translation2d(Inches.of(-24), Inches.of(24)));
-    var br = createModule(new SparkMax(10, MotorType.kBrushless),
-                          new SparkMax(11, MotorType.kBrushless),
-                          new CANcoder(12),
-                          "backright",
-                          new Translation2d(Inches.of(-24), Inches.of(-24)));
-    SwerveDriveConfig config = new SwerveDriveConfig(this, fl, fr, bl, br)
-        .withGyro(gyro.getYaw().asSupplier())
-        .withStartingPose(new Pose2d(0, 0, Rotation2d.fromDegrees(0)))
-        .withTranslationController(new PIDController(1, 0, 0))
-        .withRotationController(new PIDController(1, 0, 0));
+    var fl =
+        createModule(new SparkMax(1, MotorType.kBrushless), new SparkMax(2, MotorType.kBrushless),
+            new CANcoder(3), "frontleft", new Translation2d(Inches.of(10), Inches.of(10)));
+    var fr =
+        createModule(new SparkMax(4, MotorType.kBrushless), new SparkMax(5, MotorType.kBrushless),
+            new CANcoder(6), "frontright", new Translation2d(Inches.of(10), Inches.of(-10)));
+    var bl =
+        createModule(new SparkMax(7, MotorType.kBrushless), new SparkMax(8, MotorType.kBrushless),
+            new CANcoder(9), "backleft", new Translation2d(Inches.of(-10), Inches.of(10)));
+    var br =
+        createModule(new SparkMax(10, MotorType.kBrushless), new SparkMax(11, MotorType.kBrushless),
+            new CANcoder(12), "backright", new Translation2d(Inches.of(-10), Inches.of(-10)));
+    SwerveDriveConfig config =
+        new SwerveDriveConfig(this, fl, fr, bl, br)
+            .withGyro(gyro.getYaw().asSupplier())
+            .withMaximumChassisSpeed(MetersPerSecond.of(4), RotationsPerSecond.of(360))
+            .withStartingPose(new Pose2d(0, 0, Rotation2d.fromDegrees(0)))
+            .withTranslationController(new PIDController(1, 0, 0))
+            .withRotationController(new PIDController(1, 0, 0))
+            .withGyroAngularVelocityScaleFactor(0.3);
     drive = new SwerveDrive(config);
 
     SmartDashboard.putData("Field", field);
   }
 
-  public Command setRobotRelativeChassisSpeeds(ChassisSpeeds speeds)
-  {
+  public Command setRobotRelativeChassisSpeeds(ChassisSpeeds speeds) {
     return run(() -> drive.setRobotRelativeChassisSpeeds(speeds));
   }
 
-  public Command driveToPose(Pose2d pose)
-  {
+  public Command driveToPose(Pose2d pose) {
     return drive.driveToPose(pose);
   }
 
-  public Command driveRobotRelative(Supplier<ChassisSpeeds> speedsSupplier)
-  {
+  public Command driveRobotRelative(Supplier<ChassisSpeeds> speedsSupplier) {
     return drive.drive(speedsSupplier);
   }
 
-  public Command lock()
-  {
+  /**
+   * Drive the robot field-relative using a driver controller, converting joystick axes into
+   * {@link ChassisSpeeds} via {@link SwerveInputStream}.
+   *
+   * @param controller Driver controller to read translation/rotation axes from.
+   * @return {@link Command} that drives the robot while scheduled.
+   */
+  public Command driveWithJoystick(CommandXboxController controller) {
+    SwerveInputStream inputStream =
+        SwerveInputStream.of(drive, () -> - controller.getLeftY(), () -> - controller.getLeftX())
+            .withControllerRotationAxis(() -> - controller.getRightX())
+            .withMaximumLinearVelocity(MetersPerSecond.of(4))
+            .withMaximumAngularVelocity(DegreesPerSecond.of(360))
+            .withDeadband(0.05)
+            .withCubeTranslationControllerAxis()
+            .withAllianceRelativeControl();
+
+    return drive.drive(()
+                           -> ChassisSpeeds.fromFieldRelativeSpeeds(
+                               inputStream.get(), new Rotation2d(drive.getGyroAngle())));
+  }
+
+  public Command lock() {
     return run(drive::lockPose);
   }
 
   @Override
-  public void periodic()
-  {
+  public void periodic() {
     drive.updateTelemetry();
     field.setRobotPose(drive.getPose());
   }
 
   @Override
-  public void simulationPeriodic()
-  {
+  public void simulationPeriodic() {
     drive.simIterate();
   }
 
-  public Pose2d getPose()
-  {
+  public Pose2d getPose() {
     return drive.getPose();
   }
 
-  public ChassisSpeeds getFieldOrientedChassisSpeed()
-  {
+  public ChassisSpeeds getFieldOrientedChassisSpeed() {
     return drive.getFieldRelativeSpeed();
   }
 
-  public Angle getGyroAngle()
-  {
+  public Angle getGyroAngle() {
     return drive.getGyroAngle();
   }
 }

--- a/vendordep/src/test/java/yams/helpers/PeriodicScheduler.java
+++ b/vendordep/src/test/java/yams/helpers/PeriodicScheduler.java
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Yet Another Software Suite
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package yams.helpers;
+
+import static edu.wpi.first.units.Units.Microseconds;
+import static edu.wpi.first.units.Units.Seconds;
+
+import edu.wpi.first.units.measure.Time;
+import edu.wpi.first.wpilibj.RobotController;
+import edu.wpi.first.wpilibj.simulation.SimHooks;
+import java.util.PriorityQueue;
+
+/**
+ * Minimal, deterministic stand-in for how {@link edu.wpi.first.wpilibj.TimedRobot} runs multiple
+ * callbacks at independent periods from a single loop: a {@link PriorityQueue} of callbacks
+ * ordered by when they next come due, each rescheduled by its own period after it runs.
+ *
+ * <p>
+ * Unlike a real {@code Notifier} per callback, this advances a purely virtual timeline instead of
+ * depending on real wall-clock time or spawning any threads — {@link #runFor(Time)} runs entirely
+ * on the calling thread. It does keep WPILib's simulated FPGA clock ({@code SimHooks}/
+ * {@code RobotController}'s time source) in lockstep with that virtual timeline, since some vendor
+ * SDKs (e.g. CTRE's Phoenix6 SimState) treat status signals as stale until the FPGA clock actually
+ * advances. That makes this well suited to unit tests that need two (or more) callbacks to run at
+ * different rates against the same object — e.g. stepping simulation physics on one period while
+ * publishing telemetry on another — without the flakiness of real background-thread timing under a
+ * simulated clock.
+ * </p>
+ */
+public class PeriodicScheduler
+{
+  private final PriorityQueue<Callback> callbacks = new PriorityQueue<>();
+  private long nowMicros = 0;
+
+  public PeriodicScheduler()
+  {
+    RobotController.setTimeSource(() -> nowMicros);
+  }
+
+  /**
+   * Register a callback to run at the given period, first coming due one period from now.
+   *
+   * @param callback Callback to run each time it comes due.
+   * @param period   Period to run the callback at.
+   */
+  public void addPeriodic(Runnable callback, Time period)
+  {
+    long periodMicros = Math.round(period.in(Microseconds));
+    callbacks.add(new Callback(callback, periodMicros, nowMicros + periodMicros));
+  }
+
+  /**
+   * Advance the virtual timeline by the given duration, running every registered callback exactly
+   * as many times as its period divides into the elapsed duration, in temporal order — exactly
+   * like {@link edu.wpi.first.wpilibj.TimedRobot}'s own callback scheduler.
+   *
+   * @param duration Duration to advance the virtual timeline by.
+   */
+  public void runFor(Time duration)
+  {
+    long endMicros = nowMicros + Math.round(duration.in(Microseconds));
+    Callback next;
+    while ((next = callbacks.peek()) != null && next.expirationMicros <= endMicros)
+    {
+      callbacks.poll();
+      advanceTo(next.expirationMicros);
+      next.run.run();
+      next.expirationMicros += next.periodMicros;
+      callbacks.add(next);
+    }
+    advanceTo(endMicros);
+  }
+
+  /**
+   * Advance the virtual timeline (and WPILib's simulated FPGA clock) to the given point in time.
+   *
+   * @param targetMicros Point in time, in microseconds, to advance to.
+   */
+  private void advanceTo(long targetMicros)
+  {
+    long dtMicros = targetMicros - nowMicros;
+    nowMicros = targetMicros;
+    if (dtMicros > 0)
+    {
+      SimHooks.stepTiming(Microseconds.of(dtMicros).in(Seconds));
+    }
+  }
+
+  /**
+   * A registered periodic callback, ordered by when it next comes due.
+   */
+  private static final class Callback implements Comparable<Callback>
+  {
+    private final Runnable run;
+    private final long periodMicros;
+    private long expirationMicros;
+
+    private Callback(Runnable run, long periodMicros, long expirationMicros)
+    {
+      this.run = run;
+      this.periodMicros = periodMicros;
+      this.expirationMicros = expirationMicros;
+    }
+
+    @Override
+    public int compareTo(Callback other)
+    {
+      return Long.compare(expirationMicros, other.expirationMicros);
+    }
+  }
+}

--- a/vendordep/src/test/java/yams/helpers/PeriodicScheduler.java
+++ b/vendordep/src/test/java/yams/helpers/PeriodicScheduler.java
@@ -33,6 +33,11 @@ public class PeriodicScheduler implements AutoCloseable
 
   public PeriodicScheduler()
   {
+    // Other tests sharing this JVM (e.g. via SchedulerPumpHelper) install their own custom
+    // RobotController time source and never restore it, which can leave the clock in a stale,
+    // frozen state. Resuming (real-time) timing first forces a clean, consistent baseline before
+    // this scheduler takes manual control of it, regardless of what an earlier test left behind.
+    SimHooks.resumeTiming();
     SimHooks.pauseTiming();
   }
 
@@ -92,6 +97,18 @@ public class PeriodicScheduler implements AutoCloseable
     if (dtMicros > 0)
     {
       SimHooks.stepTiming(Microseconds.of(dtMicros).in(Seconds));
+      // Some vendor simulation SDKs (e.g. CTRE's Phoenix6 SimState) refresh their status signals
+      // from a real background thread rather than reacting to SimHooks synchronously. Since this
+      // scheduler otherwise runs a whole virtual timeline in a tight loop with no real elapsed
+      // time, that background thread may never actually get scheduled to run. Yielding a sliver of
+      // real wall-clock time here gives it a chance to catch up.
+      try
+      {
+        Thread.sleep(1);
+      } catch (InterruptedException e)
+      {
+        Thread.currentThread().interrupt();
+      }
     }
   }
 

--- a/vendordep/src/test/java/yams/helpers/PeriodicScheduler.java
+++ b/vendordep/src/test/java/yams/helpers/PeriodicScheduler.java
@@ -7,7 +7,6 @@ import static edu.wpi.first.units.Units.Microseconds;
 import static edu.wpi.first.units.Units.Seconds;
 
 import edu.wpi.first.units.measure.Time;
-import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.simulation.SimHooks;
 import java.util.PriorityQueue;
 
@@ -19,23 +18,32 @@ import java.util.PriorityQueue;
  * <p>
  * Unlike a real {@code Notifier} per callback, this advances a purely virtual timeline instead of
  * depending on real wall-clock time or spawning any threads — {@link #runFor(Time)} runs entirely
- * on the calling thread. It does keep WPILib's simulated FPGA clock ({@code SimHooks}/
- * {@code RobotController}'s time source) in lockstep with that virtual timeline, since some vendor
- * SDKs (e.g. CTRE's Phoenix6 SimState) treat status signals as stale until the FPGA clock actually
- * advances. That makes this well suited to unit tests that need two (or more) callbacks to run at
- * different rates against the same object — e.g. stepping simulation physics on one period while
- * publishing telemetry on another — without the flakiness of real background-thread timing under a
- * simulated clock.
+ * on the calling thread. Time is controlled via WPILib's own documented mechanism for this,
+ * {@link SimHooks#pauseTiming()}/{@link SimHooks#stepTiming(double)}, rather than a raw custom
+ * {@code RobotController} time source — the latter was found to leave some vendor simulation SDKs
+ * (whose own retry/config logic depends on the FPGA clock behaving exactly as WPILib expects) in
+ * an inconsistent state, silently dropping simulated hardware calls in a way that reproduced in CI
+ * but not always locally.
  * </p>
  */
-public class PeriodicScheduler
+public class PeriodicScheduler implements AutoCloseable
 {
   private final PriorityQueue<Callback> callbacks = new PriorityQueue<>();
   private long nowMicros = 0;
 
   public PeriodicScheduler()
   {
-    RobotController.setTimeSource(() -> nowMicros);
+    SimHooks.pauseTiming();
+  }
+
+  /**
+   * Resume normal (real-time) simulated timing. Call this once done, so this scheduler doesn't
+   * leave WPILib's simulated clock paused for whatever runs next.
+   */
+  @Override
+  public void close()
+  {
+    SimHooks.resumeTiming();
   }
 
   /**

--- a/vendordep/src/test/java/yams/motorcontrollers/SimulationPeriodTest.java
+++ b/vendordep/src/test/java/yams/motorcontrollers/SimulationPeriodTest.java
@@ -124,13 +124,17 @@ public class SimulationPeriodTest
       smc.setupSimulation();
 
       Angle setpoint = Degrees.of(80);
-      smc.setPosition(setpoint);
 
       int[] simIterations = {0};
       int[] telemetryIterations = {0};
       Angle finalPosition;
       try (PeriodicScheduler scheduler = new PeriodicScheduler())
       {
+        // Commanding the setpoint happens under the scheduler's own controlled clock state (started
+        // above), rather than before it, so this first call isn't at the mercy of whatever clock
+        // state an earlier test in the same JVM left behind.
+        smc.setPosition(setpoint);
+
         // simIterate() at the configured 10ms simulation period.
         scheduler.addPeriodic(() -> {
           smc.simIterate();

--- a/vendordep/src/test/java/yams/motorcontrollers/SimulationPeriodTest.java
+++ b/vendordep/src/test/java/yams/motorcontrollers/SimulationPeriodTest.java
@@ -128,23 +128,26 @@ public class SimulationPeriodTest
 
       int[] simIterations = {0};
       int[] telemetryIterations = {0};
-      PeriodicScheduler scheduler = new PeriodicScheduler();
-      // simIterate() at the configured 10ms simulation period.
-      scheduler.addPeriodic(() -> {
-        smc.simIterate();
-        simIterations[0]++;
-      }, Milliseconds.of(10));
-      // Re-commanding the setpoint and publishing telemetry at 20ms — a robot's normal periodic
-      // loop, decoupled from the (faster) simulation period above.
-      scheduler.addPeriodic(() -> {
-        smc.setPosition(setpoint);
-        smc.updateTelemetry();
-        telemetryIterations[0]++;
-      }, Milliseconds.of(20));
+      Angle finalPosition;
+      try (PeriodicScheduler scheduler = new PeriodicScheduler())
+      {
+        // simIterate() at the configured 10ms simulation period.
+        scheduler.addPeriodic(() -> {
+          smc.simIterate();
+          simIterations[0]++;
+        }, Milliseconds.of(10));
+        // Re-commanding the setpoint and publishing telemetry at 20ms — a robot's normal periodic
+        // loop, decoupled from the (faster) simulation period above.
+        scheduler.addPeriodic(() -> {
+          smc.setPosition(setpoint);
+          smc.updateTelemetry();
+          telemetryIterations[0]++;
+        }, Milliseconds.of(20));
 
-      scheduler.runFor(Seconds.of(3.0));
+        scheduler.runFor(Seconds.of(3.0));
 
-      Angle finalPosition = smc.getMechanismPosition();
+        finalPosition = smc.getMechanismPosition();
+      }
       System.out.println(smc.getName() + ": sim iterations=" + simIterations[0]
           + ", telemetry iterations=" + telemetryIterations[0]
           + ", final position=" + finalPosition.in(Degrees) + " deg (target " + setpoint.in(Degrees) + " deg)");

--- a/vendordep/src/test/java/yams/motorcontrollers/SimulationPeriodTest.java
+++ b/vendordep/src/test/java/yams/motorcontrollers/SimulationPeriodTest.java
@@ -1,0 +1,190 @@
+// Copyright (c) 2026 Yet Another Software Suite
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package yams.motorcontrollers;
+
+import static edu.wpi.first.units.Units.Amps;
+import static edu.wpi.first.units.Units.Degrees;
+import static edu.wpi.first.units.Units.Milliseconds;
+import static edu.wpi.first.units.Units.Seconds;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.ctre.phoenix6.hardware.TalonFX;
+import com.ctre.phoenix6.hardware.TalonFXS;
+import com.revrobotics.spark.SparkFlex;
+import com.revrobotics.spark.SparkMax;
+import edu.wpi.first.math.controller.SimpleMotorFeedforward;
+import edu.wpi.first.math.system.plant.DCMotor;
+import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.wpilibj.Preferences;
+import edu.wpi.first.wpilibj.simulation.RoboRioSim;
+import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import yams.gearing.GearBox;
+import yams.gearing.MechanismGearing;
+import yams.helpers.DeviceCreator;
+import yams.helpers.MockHardwareExtension;
+import yams.helpers.PeriodicScheduler;
+import yams.helpers.SmartMotorControllerTestSubsystem;
+import yams.motorcontrollers.SmartMotorControllerConfig.ControlMode;
+import yams.motorcontrollers.SmartMotorControllerConfig.MotorMode;
+import yams.motorcontrollers.SmartMotorControllerConfig.TelemetryVerbosity;
+import yams.motorcontrollers.local.SparkWrapper;
+import yams.motorcontrollers.remote.TalonFXSWrapper;
+import yams.motorcontrollers.remote.TalonFXWrapper;
+
+/**
+ * Tests that closed loop control has no negative effects when {@link SmartMotorControllerConfig#getSimulationPeriod()}
+ * differs from the robot's own periodic cadence.
+ *
+ * <p>
+ * A {@link PeriodicScheduler} — a small stand-in for how {@link edu.wpi.first.wpilibj.TimedRobot}'s
+ * own {@code addPeriodic()} runs multiple callbacks at independent periods from a single loop —
+ * calls {@link SmartMotorController#simIterate()} at the configured 10ms simulation period and a
+ * separate callback (re-commanding the setpoint and publishing telemetry) at 20ms, mirroring a
+ * robot whose periodic loop runs at 20ms while simulation physics steps at 10ms. This runs
+ * entirely on the calling thread against a virtual timeline — no real-time Notifier, no WPILib
+ * simulation timing hooks — so it is fully deterministic. The test runs across every vendor
+ * wrapper (Spark, TalonFXS, TalonFX) so a regression in any one wrapper's {@code simIterate()}
+ * would be caught.
+ * </p>
+ */
+public class SimulationPeriodTest
+{
+  private static Stream<Arguments> createConfigs()
+  {
+    SmartMotorControllerConfig baseConfig = new SmartMotorControllerConfig()
+        .withGearing(new MechanismGearing(GearBox.fromReductionStages(3, 4)))
+        .withClosedLoopController(8, 0, 0)
+        .withFeedforward(new SimpleMotorFeedforward(0, 1))
+        .withStatorCurrentLimit(Amps.of(40))
+        .withIdleMode(MotorMode.BRAKE)
+        .withControlMode(ControlMode.CLOSED_LOOP)
+        .withSimulationPeriod(Milliseconds.of(10))
+        .withStartingPosition(Degrees.of(0));
+
+    return Stream.of(
+        Arguments.of(new SparkWrapper(DeviceCreator.createSparkMax(), DCMotor.getNEO(1),
+            baseConfig.clone()
+                      .withSubsystem(new SmartMotorControllerTestSubsystem())
+                      .withTelemetry("SimulationPeriodTest SparkMax", TelemetryVerbosity.LOW))),
+        Arguments.of(new SparkWrapper(DeviceCreator.createSparkFlex(), DCMotor.getNeoVortex(1),
+            baseConfig.clone()
+                      .withSubsystem(new SmartMotorControllerTestSubsystem())
+                      .withTelemetry("SimulationPeriodTest SparkFlex", TelemetryVerbosity.LOW))),
+        Arguments.of(new TalonFXSWrapper(DeviceCreator.createTalonFXS(), DCMotor.getNEO(1),
+            baseConfig.clone()
+                      .withSubsystem(new SmartMotorControllerTestSubsystem())
+                      .withTelemetry("SimulationPeriodTest TalonFXS", TelemetryVerbosity.LOW))),
+        Arguments.of(new TalonFXWrapper(DeviceCreator.createTalonFX(), DCMotor.getKrakenX60(1),
+            baseConfig.clone()
+                      .withSubsystem(new SmartMotorControllerTestSubsystem())
+                      .withTelemetry("SimulationPeriodTest TalonFX", TelemetryVerbosity.LOW)))
+    );
+  }
+
+  private static void closeSmc(SmartMotorController smc)
+  {
+    SmartMotorControllerTestSubsystem subsys =
+        (SmartMotorControllerTestSubsystem) smc.getConfig().getSubsystem();
+    SmartMotorControllerCommandRegistry.removeCommands(subsys);
+    CommandScheduler.getInstance().unregisterSubsystem(subsys);
+    subsys.close();
+
+    Object motorController = smc.getMotorController();
+    if (motorController instanceof SparkMax)
+    {
+      ((SparkMax) motorController).close();
+    } else if (motorController instanceof SparkFlex)
+    {
+      ((SparkFlex) motorController).close();
+    } else if (motorController instanceof TalonFXS)
+    {
+      ((TalonFXS) motorController).close();
+    } else if (motorController instanceof TalonFX)
+    {
+      ((TalonFX) motorController).close();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("createConfigs")
+  void testSimIterateAccurateWithSlowerTelemetryPeriod(SmartMotorController smc)
+  {
+    try
+    {
+      SmartMotorControllerTestSubsystem subsys =
+          (SmartMotorControllerTestSubsystem) smc.getConfig().getSubsystem();
+      subsys.setSMC(smc);
+      smc.setupSimulation();
+
+      Angle setpoint = Degrees.of(80);
+      smc.setPosition(setpoint);
+
+      int[] simIterations = {0};
+      int[] telemetryIterations = {0};
+      PeriodicScheduler scheduler = new PeriodicScheduler();
+      // simIterate() at the configured 10ms simulation period.
+      scheduler.addPeriodic(() -> {
+        smc.simIterate();
+        simIterations[0]++;
+      }, Milliseconds.of(10));
+      // Re-commanding the setpoint and publishing telemetry at 20ms — a robot's normal periodic
+      // loop, decoupled from the (faster) simulation period above.
+      scheduler.addPeriodic(() -> {
+        smc.setPosition(setpoint);
+        smc.updateTelemetry();
+        telemetryIterations[0]++;
+      }, Milliseconds.of(20));
+
+      scheduler.runFor(Seconds.of(3.0));
+
+      Angle finalPosition = smc.getMechanismPosition();
+      System.out.println(smc.getName() + ": sim iterations=" + simIterations[0]
+          + ", telemetry iterations=" + telemetryIterations[0]
+          + ", final position=" + finalPosition.in(Degrees) + " deg (target " + setpoint.in(Degrees) + " deg)");
+
+      // Over 1.5s, a 10ms period should fire ~150 times and a 20ms period ~75 times — roughly twice
+      // as often — confirming simIterate() genuinely ran at the configured simulation period rather
+      // than some other period.
+      assertTrue(simIterations[0] > telemetryIterations[0],
+          smc.getName() + ": expected simIterate() (10ms) to run more often than the periodic loop (20ms).");
+
+      // Closed loop position control should still converge to the setpoint even though simIterate()
+      // runs at a different rate than the periodic loop. The regression this guards against is the
+      // simulated motor moving too far (or too little) per physics step because the sim step size
+      // was conflated with some other loop's period instead of the configured simulation period —
+      // that shows up as an error of 100+ degrees (as observed while developing this test), not a
+      // few degrees of jitter, so a generous tolerance here still catches a real regression while
+      // absorbing CTRE's own background CAN-refresh-thread timing jitter under simulation.
+      assertTrue(finalPosition.isNear(setpoint, Degrees.of(5)),
+          smc.getName() + ": closed loop position control should converge to the setpoint with a "
+              + "10ms simulation period and a 20ms periodic loop period.");
+    } finally
+    {
+      closeSmc(smc);
+    }
+  }
+
+  @BeforeEach
+  void startTest()
+  {
+    MockHardwareExtension.beforeAll();
+    // Guard against a sagged simulated battery voltage left behind by other test classes sharing
+    // this JVM's BatterySim/RoboRioSim static state, so this test's convergence isn't at the mercy
+    // of full-suite run order.
+    RoboRioSim.setVInVoltage(12.0);
+  }
+
+  @AfterEach
+  void endTest()
+  {
+    MockHardwareExtension.afterAll();
+    Preferences.removeAll();
+  }
+}

--- a/vendordep/src/test/java/yams/motorcontrollers/simulation/BatterySimTest.java
+++ b/vendordep/src/test/java/yams/motorcontrollers/simulation/BatterySimTest.java
@@ -1,0 +1,228 @@
+// Copyright (c) 2026 Yet Another Software Suite
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package yams.motorcontrollers.simulation;
+
+import static edu.wpi.first.units.Units.Amps;
+import static edu.wpi.first.units.Units.MilliOhms;
+import static edu.wpi.first.units.Units.Seconds;
+import static edu.wpi.first.units.Units.Volts;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.ctre.phoenix6.hardware.TalonFX;
+import com.ctre.phoenix6.hardware.TalonFXS;
+import com.revrobotics.spark.SparkFlex;
+import com.revrobotics.spark.SparkMax;
+import edu.wpi.first.math.system.plant.DCMotor;
+import edu.wpi.first.wpilibj.Preferences;
+import edu.wpi.first.wpilibj.simulation.RoboRioSim;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import yams.gearing.GearBox;
+import yams.gearing.MechanismGearing;
+import yams.helpers.DeviceCreator;
+import yams.helpers.MockHardwareExtension;
+import yams.helpers.SmartMotorControllerTestSubsystem;
+import yams.helpers.TestWithScheduler;
+import yams.motorcontrollers.SmartMotorController;
+import yams.motorcontrollers.SmartMotorControllerCommandRegistry;
+import yams.motorcontrollers.SmartMotorControllerConfig;
+import yams.motorcontrollers.SmartMotorControllerConfig.ControlMode;
+import yams.motorcontrollers.SmartMotorControllerConfig.MotorMode;
+import yams.motorcontrollers.SmartMotorControllerConfig.TelemetryVerbosity;
+import yams.motorcontrollers.local.SparkWrapper;
+import yams.motorcontrollers.remote.TalonFXSWrapper;
+import yams.motorcontrollers.remote.TalonFXWrapper;
+
+/**
+ * Tests that {@link BatterySim} models the shared simulated battery sagging and draining as
+ * multiple {@link SmartMotorController}s draw heavy current simultaneously, mirroring what happens
+ * on a real robot when several mechanisms are commanded at once.
+ */
+public class BatterySimTest
+{
+  private static int offset = 0;
+
+  /**
+   * Build four heavily-loadable {@link SmartMotorController}s (one per supported vendor wrapper),
+   * each with its own {@link SmartMotorControllerTestSubsystem} and simulation set up, ready to be
+   * commanded to a heavy duty cycle.
+   */
+  private static List<SmartMotorController> createHeavyLoadSmcs()
+  {
+    offset += 1;
+    SmartMotorControllerConfig baseConfig = new SmartMotorControllerConfig()
+        .withGearing(new MechanismGearing(GearBox.fromReductionStages(3, 4)))
+        .withIdleMode(MotorMode.COAST)
+        .withStatorCurrentLimit(Amps.of(80))
+        .withMotorInverted(false)
+        .withControlMode(ControlMode.OPEN_LOOP);
+
+    List<SmartMotorController> smcs = new ArrayList<>();
+    smcs.add(new SparkWrapper(DeviceCreator.createSparkMax(), DCMotor.getNEO(1),
+        baseConfig.clone()
+                  .withSubsystem(new SmartMotorControllerTestSubsystem())
+                  .withTelemetry("BatterySim SparkMax(" + (10 + offset) + ") NEO", TelemetryVerbosity.LOW)));
+    smcs.add(new SparkWrapper(DeviceCreator.createSparkFlex(), DCMotor.getNeoVortex(1),
+        baseConfig.clone()
+                  .withSubsystem(new SmartMotorControllerTestSubsystem())
+                  .withTelemetry("BatterySim SparkFlex(" + (20 + offset) + ") Vortex", TelemetryVerbosity.LOW)));
+    smcs.add(new TalonFXSWrapper(DeviceCreator.createTalonFXS(), DCMotor.getNEO(1),
+        baseConfig.clone()
+                  .withSubsystem(new SmartMotorControllerTestSubsystem())
+                  .withTelemetry("BatterySim TalonFXS(" + (30 + offset) + ") NEO", TelemetryVerbosity.LOW)));
+    smcs.add(new TalonFXWrapper(DeviceCreator.createTalonFX(), DCMotor.getKrakenX60(1),
+        baseConfig.clone()
+                  .withSubsystem(new SmartMotorControllerTestSubsystem())
+                  .withTelemetry("BatterySim TalonFX(" + (40 + offset) + ") Kraken", TelemetryVerbosity.LOW)));
+
+    for (SmartMotorController smc : smcs)
+    {
+      SmartMotorControllerTestSubsystem subsys = (SmartMotorControllerTestSubsystem) smc.getConfig().getSubsystem();
+      subsys.setSMC(smc);
+      smc.setupSimulation();
+      subsys.testRunning = true;
+    }
+    return smcs;
+  }
+
+  /**
+   * Schedule a heavy (near-stall) duty cycle command for the given {@link SmartMotorController}.
+   */
+  private static Command heavyLoadCommand(SmartMotorController smc)
+  {
+    return ((SmartMotorControllerTestSubsystem) smc.getConfig().getSubsystem()).setDutyCycle(1.0);
+  }
+
+  /**
+   * Close an {@link SmartMotorController} and its underlying vendor device, freeing HAL handles and
+   * scheduler registrations.
+   */
+  private static void closeSmc(SmartMotorController smc)
+  {
+    SmartMotorControllerCommandRegistry.removeCommands(smc.getConfig().getSubsystem());
+    CommandScheduler.getInstance().unregisterSubsystem(
+        (SmartMotorControllerTestSubsystem) smc.getConfig().getSubsystem());
+    ((SmartMotorControllerTestSubsystem) smc.getConfig().getSubsystem()).close();
+
+    Object motorController = smc.getMotorController();
+    if (motorController instanceof SparkMax)
+    {
+      ((SparkMax) motorController).close();
+    } else if (motorController instanceof SparkFlex)
+    {
+      ((SparkFlex) motorController).close();
+    } else if (motorController instanceof TalonFXS)
+    {
+      ((TalonFXS) motorController).close();
+    } else if (motorController instanceof TalonFX)
+    {
+      ((TalonFX) motorController).close();
+    }
+  }
+
+  /**
+   * Track the lowest {@link RoboRioSim#getVInVoltage()} seen while cycling the scheduler for the
+   * given duration. Each registered subsystem's {@code simulationPeriodic()} updates the shared
+   * battery voltage sequentially within a tick, so a single instantaneous read after the fact is
+   * noisy; the minimum over the whole window reliably captures the worst-case sag instead.
+   */
+  private static double minVoltageOverCycle(double seconds) throws InterruptedException
+  {
+    double[] minVoltage = {RoboRioSim.getVInVoltage()};
+    TestWithScheduler.cycle(Seconds.of(seconds),
+        () -> minVoltage[0] = Math.min(minVoltage[0], RoboRioSim.getVInVoltage()));
+    return minVoltage[0];
+  }
+
+  @Test
+  void testHeavyLoadFromMultipleSmcsSagsBatteryVoltage() throws InterruptedException
+  {
+    List<SmartMotorController> smcs = createHeavyLoadSmcs();
+    try
+    {
+      // Let the sim settle at idle (zero duty cycle) and record the baseline voltage.
+      double idleVoltage = minVoltageOverCycle(0.5);
+
+      // Command a single motor to a heavy duty cycle and measure the resulting sag.
+      TestWithScheduler.schedule(heavyLoadCommand(smcs.get(0)));
+      double singleMotorVoltage = minVoltageOverCycle(0.3);
+
+      // Now command every remaining motor to a heavy duty cycle at the same time.
+      for (int i = 1; i < smcs.size(); i++)
+      {
+        TestWithScheduler.schedule(heavyLoadCommand(smcs.get(i)));
+      }
+      double allMotorsVoltage = minVoltageOverCycle(0.3);
+
+      System.out.println("Idle voltage: " + idleVoltage);
+      System.out.println("Single motor heavy load voltage: " + singleMotorVoltage);
+      System.out.println("All motors heavy load voltage: " + allMotorsVoltage);
+
+      assertTrue(singleMotorVoltage < idleVoltage,
+          "Voltage should sag below idle once a single motor is drawing heavy current.");
+      assertTrue(allMotorsVoltage < singleMotorVoltage,
+          "Voltage should sag further once every motor is drawing heavy current simultaneously.");
+    } finally
+    {
+      smcs.forEach(BatterySimTest::closeSmc);
+    }
+  }
+
+  @Test
+  void testSustainedHeavyLoadDrainsBatteryStateOfCharge() throws InterruptedException
+  {
+    // Use a small capacity so a couple of simulated seconds of heavy current draw is a measurable
+    // fraction of the battery, without needing to simulate a realistic multi-hour match.
+    // @implNote BatterySim's current-draw bookkeeping is process-global and never cleared per SMC,
+    // so other test classes' leftover current draws can still be contributing when this runs as
+    // part of the full suite; only assert the direction of the drain (strictly below full), not a
+    // specific magnitude, so the test stays reliable regardless of run order.
+    BatterySim.enableDischarge(2.0, Volts.of(12.0), MilliOhms.of(20));
+    List<SmartMotorController> smcs = createHeavyLoadSmcs();
+    try
+    {
+      assertTrue(BatterySim.getStateOfCharge() == 1.0, "Battery should start fully charged.");
+
+      for (SmartMotorController smc : smcs)
+      {
+        TestWithScheduler.schedule(heavyLoadCommand(smc));
+      }
+      TestWithScheduler.cycle(Seconds.of(0.2));
+
+      double stateOfCharge = BatterySim.getStateOfCharge();
+      System.out.println("State of charge after sustained heavy load: " + stateOfCharge);
+      assertTrue(stateOfCharge < 1.0,
+          "Sustained heavy current draw from multiple motors should drain the battery's state of "
+              + "charge.");
+    } finally
+    {
+      smcs.forEach(BatterySimTest::closeSmc);
+      BatterySim.disableDischarge();
+    }
+  }
+
+  @BeforeEach
+  void startTest()
+  {
+    MockHardwareExtension.beforeAll();
+    TestWithScheduler.schedulerStart();
+    TestWithScheduler.schedulerClear();
+    BatterySim.disableDischarge();
+    BatterySim.resetDischarge();
+  }
+
+  @AfterEach
+  void endTest()
+  {
+    BatterySim.disableDischarge();
+    MockHardwareExtension.afterAll();
+    Preferences.removeAll();
+    TestWithScheduler.schedulerClear();
+  }
+}

--- a/vendordep/src/test/java/yams/motorcontrollers/simulation/BatterySimTest.java
+++ b/vendordep/src/test/java/yams/motorcontrollers/simulation/BatterySimTest.java
@@ -4,6 +4,7 @@
 package yams.motorcontrollers.simulation;
 
 import static edu.wpi.first.units.Units.Amps;
+import static edu.wpi.first.units.Units.KilogramSquareMeters;
 import static edu.wpi.first.units.Units.MilliOhms;
 import static edu.wpi.first.units.Units.Seconds;
 import static edu.wpi.first.units.Units.Volts;
@@ -49,6 +50,12 @@ public class BatterySimTest
   private static int offset = 0;
 
   /**
+   * Allowed slack when asserting that voltage does not rise, to absorb floating point/timing
+   * noise without masking a real regression (which showed up as multi-volt jumps).
+   */
+  private static final double VOLTAGE_RISE_TOLERANCE = 0.05;
+
+  /**
    * Build four heavily-loadable {@link SmartMotorController}s (one per supported vendor wrapper),
    * each with its own {@link SmartMotorControllerTestSubsystem} and simulation set up, ready to be
    * commanded to a heavy duty cycle.
@@ -61,7 +68,12 @@ public class BatterySimTest
         .withIdleMode(MotorMode.COAST)
         .withStatorCurrentLimit(Amps.of(80))
         .withMotorInverted(false)
-        .withControlMode(ControlMode.OPEN_LOOP);
+        .withControlMode(ControlMode.OPEN_LOOP)
+        // A heavy load (well above the 0.02 kgm^2 default) keeps the motor accelerating slowly, so
+        // it stays near its high-current stall region for the whole test window instead of
+        // quickly spinning up towards free speed and current dropping off — a stable, heavily
+        // loaded mechanism rather than a fast, lightly loaded one.
+        .withMomentOfInertia(KilogramSquareMeters.of(2.0));
 
     List<SmartMotorController> smcs = new ArrayList<>();
     smcs.add(new SparkWrapper(DeviceCreator.createSparkMax(), DCMotor.getNEO(1),
@@ -92,11 +104,37 @@ public class BatterySimTest
   }
 
   /**
+   * Build a duty cycle command for the given {@link SmartMotorController}.
+   */
+  private static Command dutyCycleCommand(SmartMotorController smc, double dutyCycle)
+  {
+    return ((SmartMotorControllerTestSubsystem) smc.getConfig().getSubsystem()).setDutyCycle(dutyCycle);
+  }
+
+  /**
    * Schedule a heavy (near-stall) duty cycle command for the given {@link SmartMotorController}.
    */
   private static Command heavyLoadCommand(SmartMotorController smc)
   {
-    return ((SmartMotorControllerTestSubsystem) smc.getConfig().getSubsystem()).setDutyCycle(1.0);
+    return dutyCycleCommand(smc, 1.0);
+  }
+
+  /**
+   * Force the simulated battery to a fully depleted state by enabling discharge with a
+   * vanishingly small capacity and running a brief heavy load — any nonzero current instantly
+   * exhausts it. Returns the {@link SmartMotorController}s used to do it, still under heavy load,
+   * so the caller can drive further scenarios (e.g. idling or continuing to load a dead battery).
+   */
+  private static List<SmartMotorController> drainBatteryToEmpty() throws InterruptedException
+  {
+    BatterySim.enableDischarge(1e-6, Volts.of(12.0), MilliOhms.of(20));
+    List<SmartMotorController> smcs = createHeavyLoadSmcs();
+    for (SmartMotorController smc : smcs)
+    {
+      TestWithScheduler.schedule(heavyLoadCommand(smc));
+    }
+    TestWithScheduler.cycle(Seconds.of(0.1));
+    return smcs;
   }
 
   /**
@@ -131,10 +169,15 @@ public class BatterySimTest
    * given duration. Each registered subsystem's {@code simulationPeriodic()} updates the shared
    * battery voltage sequentially within a tick, so a single instantaneous read after the fact is
    * noisy; the minimum over the whole window reliably captures the worst-case sag instead.
+   *
+   * @implNote Seeded with {@link Double#POSITIVE_INFINITY}, not the pre-cycle voltage — the latter
+   * can be a stale reading from before this window's simulation ticks ran (e.g. the raw HAL default
+   * of 12V, which is below a fully-charged battery's true ~12.9V open circuit voltage), which would
+   * otherwise mask the real value for this window and make a later window look like a false rise.
    */
   private static double minVoltageOverCycle(double seconds) throws InterruptedException
   {
-    double[] minVoltage = {RoboRioSim.getVInVoltage()};
+    double[] minVoltage = {Double.POSITIVE_INFINITY};
     TestWithScheduler.cycle(Seconds.of(seconds),
         () -> minVoltage[0] = Math.min(minVoltage[0], RoboRioSim.getVInVoltage()));
     return minVoltage[0];
@@ -200,6 +243,146 @@ public class BatterySimTest
       assertTrue(stateOfCharge < 1.0,
           "Sustained heavy current draw from multiple motors should drain the battery's state of "
               + "charge.");
+    } finally
+    {
+      smcs.forEach(BatterySimTest::closeSmc);
+      BatterySim.disableDischarge();
+    }
+  }
+
+  @Test
+  void testFullyChargedBatteryVoltage() throws InterruptedException
+  {
+    BatterySim.enableDischarge(2.0, Volts.of(12.0), MilliOhms.of(20));
+    List<SmartMotorController> smcs = createHeavyLoadSmcs();
+    try
+    {
+      assertTrue(BatterySim.getStateOfCharge() == 1.0, "Battery should start fully charged.");
+
+      // A fresh, fully charged battery sits at the top of BatterySim's discharge curve, above the
+      // flat 12 V used when discharge simulation is disabled.
+      double idleVoltage = minVoltageOverCycle(0.2);
+      System.out.println("Fully charged idle voltage: " + idleVoltage);
+      assertTrue(idleVoltage > 12.0,
+          "A fully charged, unloaded battery should read above nominal 12V.");
+
+      for (SmartMotorController smc : smcs)
+      {
+        TestWithScheduler.schedule(heavyLoadCommand(smc));
+      }
+      double loadedVoltage = minVoltageOverCycle(0.2);
+      System.out.println("Fully charged voltage under heavy load: " + loadedVoltage);
+
+      assertTrue(loadedVoltage < idleVoltage,
+          "Voltage should sag from nominal once multiple motors draw heavy current, even on a full battery.");
+      assertTrue(BatterySim.getStateOfCharge() < 1.0,
+          "Drawing current from a fully charged battery should begin depleting its state of charge.");
+    } finally
+    {
+      smcs.forEach(BatterySimTest::closeSmc);
+      BatterySim.disableDischarge();
+    }
+  }
+
+  @Test
+  void testEmptyBatteryVoltage() throws InterruptedException
+  {
+    List<SmartMotorController> smcs = drainBatteryToEmpty();
+    try
+    {
+      assertTrue(BatterySim.getStateOfCharge() == 0.0, "Battery should be fully depleted.");
+
+      // Stop drawing current and let the depleted battery settle towards its empty open-circuit
+      // voltage, which BatterySim's discharge curve puts well below a healthy battery's ~12 V.
+      for (SmartMotorController smc : smcs)
+      {
+        TestWithScheduler.schedule(dutyCycleCommand(smc, 0.0));
+      }
+      double deadIdleVoltage = minVoltageOverCycle(0.2);
+      System.out.println("Depleted battery idle voltage: " + deadIdleVoltage);
+      assertTrue(deadIdleVoltage < 10.0,
+          "A fully depleted battery should sag well below a healthy battery's nominal voltage.");
+    } finally
+    {
+      smcs.forEach(BatterySimTest::closeSmc);
+      BatterySim.disableDischarge();
+    }
+  }
+
+  @Test
+  void testVoltageDoesNotRiseWithMoreSmcsUnderHeavyLoad() throws InterruptedException
+  {
+    // Compare a single motor alone against every motor at once, each starting from an equally
+    // fresh battery. (Incrementally adding motors one at a time across staggered time windows was
+    // tried first and is not a reliable comparison: motor stall current decays as it spins up, so
+    // the worst instantaneous demand doesn't necessarily grow in lockstep with motor count over
+    // time — that's a real transient-dynamics property, not something worth asserting on.)
+    BatterySim.enableDischarge(2.0, Volts.of(12.0), MilliOhms.of(20));
+    List<SmartMotorController> soloSmcs = createHeavyLoadSmcs();
+    double soloVoltage;
+    try
+    {
+      TestWithScheduler.schedule(heavyLoadCommand(soloSmcs.get(0)));
+      soloVoltage = minVoltageOverCycle(0.3);
+    } finally
+    {
+      // Cancel the still-running heavy-load command before closing its device — otherwise the
+      // scheduler tries to execute it against an already-closed SMC on the next cycle.
+      TestWithScheduler.schedulerClear();
+      soloSmcs.forEach(BatterySimTest::closeSmc);
+    }
+
+    BatterySim.resetDischarge();
+    List<SmartMotorController> manySmcs = createHeavyLoadSmcs();
+    double manyVoltage;
+    try
+    {
+      for (SmartMotorController smc : manySmcs)
+      {
+        TestWithScheduler.schedule(heavyLoadCommand(smc));
+      }
+      manyVoltage = minVoltageOverCycle(0.3);
+    } finally
+    {
+      manySmcs.forEach(BatterySimTest::closeSmc);
+      BatterySim.disableDischarge();
+    }
+
+    System.out.println("Single motor heavy load voltage: " + soloVoltage);
+    System.out.println("Many motors heavy load voltage: " + manyVoltage);
+    assertTrue(manyVoltage <= soloVoltage + VOLTAGE_RISE_TOLERANCE,
+        "An SMC's available voltage should not be higher when many other SMCs are also drawing "
+            + "heavy current than when it is drawing heavy current alone.");
+  }
+
+  @Test
+  void testVoltageDoesNotRiseWhenBatteryIsDead() throws InterruptedException
+  {
+    List<SmartMotorController> smcs = drainBatteryToEmpty();
+    try
+    {
+      assertTrue(BatterySim.getStateOfCharge() == 0.0, "Battery should be fully depleted.");
+
+      // Let the depleted battery idle and record its baseline voltage.
+      for (SmartMotorController smc : smcs)
+      {
+        TestWithScheduler.schedule(dutyCycleCommand(smc, 0.0));
+      }
+      double deadIdleVoltage = minVoltageOverCycle(0.2);
+
+      // The battery is already empty; hammering every motor with a heavy duty cycle again must not
+      // make the reported voltage climb back up.
+      for (SmartMotorController smc : smcs)
+      {
+        TestWithScheduler.schedule(heavyLoadCommand(smc));
+      }
+      double deadLoadedVoltage = minVoltageOverCycle(0.2);
+
+      System.out.println("Dead battery idle voltage: " + deadIdleVoltage);
+      System.out.println("Dead battery voltage under heavy load: " + deadLoadedVoltage);
+      assertTrue(deadLoadedVoltage <= deadIdleVoltage + VOLTAGE_RISE_TOLERANCE,
+          "Voltage should not rise above the depleted-battery baseline just because motors are drawing heavy "
+              + "current.");
     } finally
     {
       smcs.forEach(BatterySimTest::closeSmc);

--- a/yams/java/yams/mechanisms/config/SwerveDriveConfig.java
+++ b/yams/java/yams/mechanisms/config/SwerveDriveConfig.java
@@ -3,6 +3,9 @@
 
 package yams.mechanisms.config;
 
+import static edu.wpi.first.units.Units.Microsecond;
+import static edu.wpi.first.units.Units.Milliseconds;
+import static edu.wpi.first.units.Units.Radians;
 import static edu.wpi.first.units.Units.RadiansPerSecond;
 import static edu.wpi.first.units.Units.Rotations;
 import static edu.wpi.first.units.Units.Seconds;
@@ -17,12 +20,14 @@ import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.units.measure.LinearVelocity;
 import edu.wpi.first.units.measure.Time;
+import edu.wpi.first.wpilibj.Alert;
 import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj2.command.Subsystem;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.function.Supplier;
 
+import yams.math.DerivativeTimeFilter;
 import yams.mechanisms.swerve.SwerveDrive;
 import yams.mechanisms.swerve.SwerveModule;
 import yams.motorcontrollers.SmartMotorControllerConfig.TelemetryVerbosity;
@@ -136,6 +141,17 @@ public class SwerveDriveConfig
    * Gyro angular velocity supplier.
    */
   private Optional<Supplier<AngularVelocity>> gyroAngularVelocitySupplier   = Optional.empty();
+  /**
+   * Derives the gyro angular velocity from the gyro angle ({@link #getGyroAngle()}) when
+   * {@link #gyroAngularVelocitySupplier} is not configured, in both simulation and real robot code.
+   */
+  private final DerivativeTimeFilter          gyroAngularVelocityFilter    = new DerivativeTimeFilter(Milliseconds.of(20));
+  /**
+   * Alert shown once if {@link #angularVelocitySkewCorrection(ChassisSpeeds)} runs without a
+   * {@link #gyroAngularVelocitySupplier} configured, warning that the gyro angular velocity is being derived from
+   * the gyro angle instead.
+   */
+  private Alert                               noGyroAngularVelocitySupplierAlert = null;
   /**
    * Gyro offset.
    */
@@ -627,14 +643,32 @@ public class SwerveDriveConfig
    */
   private ChassisSpeeds angularVelocitySkewCorrection(ChassisSpeeds robotRelativeVelocity)
   {
-    var angularVelocity = new Rotation2d(gyroAngularVelocitySupplier.orElseThrow().get().in(RadiansPerSecond) *
-                                         (RobotBase.isSimulation() ?
-                                          simAngularVelocityScaleFactor.orElse(angularVelocityScaleFactor.orElseThrow())
-                                                                   :
-                                          angularVelocityScaleFactor.orElseThrow()));
+    AngularVelocity gyroAngularVelocity;
+    if (gyroAngularVelocitySupplier.isPresent())
+    {
+      gyroAngularVelocity = gyroAngularVelocitySupplier.get().get();
+    }
+    else
+    {
+      if (noGyroAngularVelocitySupplierAlert == null)
+      {
+        noGyroAngularVelocitySupplierAlert = new Alert("YAMS",
+            getTelemetryName() + " has an angular velocity scale factor configured but no gyro angular velocity "
+                + "supplier (see SwerveDriveConfig#withGyroVelocity); deriving it from the gyro angle instead.",
+            Alert.AlertType.kInfo);
+        noGyroAngularVelocitySupplierAlert.set(true);
+      }
+      gyroAngularVelocity =
+          Radians.per(Microsecond).of(gyroAngularVelocityFilter.derivative(getGyroAngle().in(Radians)));
+    }
+    var angularVelocityScale = (RobotBase.isSimulation() ?
+                                simAngularVelocityScaleFactor.orElse(angularVelocityScaleFactor.orElseThrow())
+                                                         :
+                                angularVelocityScaleFactor.orElseThrow());
+    var angularVelocity = new Rotation2d(gyroAngularVelocity.in(RadiansPerSecond) * angularVelocityScale);
     if (angularVelocity.getRadians() != 0.0)
     {
-      var           gyroRotation          = new Rotation2d(gyroSupplier.orElseThrow().get());
+      var           gyroRotation          = new Rotation2d(getGyroAngle());
       ChassisSpeeds fieldRelativeVelocity = ChassisSpeeds.fromRobotRelativeSpeeds(robotRelativeVelocity, gyroRotation);
       robotRelativeVelocity = ChassisSpeeds.fromFieldRelativeSpeeds(fieldRelativeVelocity,
                                                                     gyroRotation.plus(angularVelocity));

--- a/yams/java/yams/mechanisms/config/SwerveDriveConfig.java
+++ b/yams/java/yams/mechanisms/config/SwerveDriveConfig.java
@@ -239,6 +239,44 @@ public class SwerveDriveConfig
   {
   }
 
+  private SwerveDriveConfig(SwerveDriveConfig cfg)
+  {
+    this.telemetryVerbosity = cfg.telemetryVerbosity;
+    this.specifiedTelemetryConfig = cfg.specifiedTelemetryConfig;
+    this.initialPose = cfg.initialPose;
+    this.maximumChassisLinearVelocity = cfg.maximumChassisLinearVelocity;
+    this.maximumChassisAngularVelocity = cfg.maximumChassisAngularVelocity;
+    this.maximumModuleLinearVelocity = cfg.maximumModuleLinearVelocity;
+    this.discretizationSeconds = cfg.discretizationSeconds;
+    this.angularVelocityScaleFactor = cfg.angularVelocityScaleFactor;
+    this.centerOfRotation = cfg.centerOfRotation;
+    this.translationController = cfg.translationController;
+    this.rotationController = cfg.rotationController;
+    this.simTranslationController = cfg.simTranslationController;
+    this.simRotationController = cfg.simRotationController;
+    this.simDiscretizationSeconds = cfg.simDiscretizationSeconds;
+    this.simAngularVelocityScaleFactor = cfg.simAngularVelocityScaleFactor;
+    // Intentionally not copying these, as they are not user-configurable.
+//    this.gyroSupplier = cfg.gyroSupplier;
+//    this.gyroAngularVelocitySupplier = cfg.gyroAngularVelocitySupplier;
+//    this.gyroOffset = cfg.gyroOffset;
+//    this.gyroInverted = cfg.gyroInverted;
+//    this.telemetryName = cfg.telemetryName;
+//    this.modules = cfg.modules;
+//    this.subsystem = cfg.subsystem;
+//    this.noGyroAngularVelocitySupplierAlert = cfg.noGyroAngularVelocitySupplierAlert;
+  }
+
+  /**
+   * Clone the {@link SwerveDriveConfig} without modules, subsystem, telemetry name, gyro supplier, gyro angular velocity supplier,
+   * gyro offset, and gyro inversion.
+   * @return New {@link SwerveDriveConfig}
+   */
+  public SwerveDriveConfig clone()
+  {
+    return new SwerveDriveConfig(this);
+  }
+
   /**
    * Define a {@link Subsystem} for the {@link SwerveDrive}
    *

--- a/yams/java/yams/mechanisms/swerve/SwerveDrive.java
+++ b/yams/java/yams/mechanisms/swerve/SwerveDrive.java
@@ -191,7 +191,7 @@ public class SwerveDrive {
   /**
    * Setup telemetry for the drive; the {@link SwerveDriveTelemetry} config used is either the one
    * supplied via
-   * {@link SwerveDriveConfig#withTelemetry(SwerveDriveTelemetryConfig)} or a default built from
+   * {@link SwerveDriveConfig#withTelemetry(String,SwerveDriveTelemetryConfig)} or a default built from
    * {@link SwerveDriveConfig#getTelemetryVerbosity()} (defaulting to {@link
    * TelemetryVerbosity#HIGH}).
    */
@@ -229,8 +229,7 @@ public class SwerveDrive {
    */
   public Command drive(Supplier<ChassisSpeeds> robotRelativeChassisSpeeds) {
     return Commands
-        .run(()
-                 -> setRobotRelativeChassisSpeeds(robotRelativeChassisSpeeds.get()),
+        .run(() -> setRobotRelativeChassisSpeeds(robotRelativeChassisSpeeds.get()),
             m_config.getSubsystem())
         .withName("Drive");
   }

--- a/yams/java/yams/mechanisms/swerve/SwerveDrive.java
+++ b/yams/java/yams/mechanisms/swerve/SwerveDrive.java
@@ -210,13 +210,11 @@ public class SwerveDrive {
     m_swerveTelemetry.setupTelemetry(this);
     m_field2d.setRobotPose(getPose());
     SmartDashboard.putData("Mechanisms/" + getName() + "/field", m_field2d);
-    SmartDashboard.putData(
-        "Mechanisms/" + getName() + "/tuning", Commands.startRun(() -> {
-          System.out.println(
-              "================= Starting SwerveDrive Tuning =================\n");
-          resetTranslationPID();
-          resetRotationPID();
-        }, () -> m_swerveTelemetry.applyTuningValues(this)));
+    SmartDashboard.putData("Mechanisms/" + getName() + "/tuning", Commands.startRun(() -> {
+      System.out.println("================= Starting SwerveDrive Tuning =================\n");
+      resetTranslationPID();
+      resetRotationPID();
+    }, () -> m_swerveTelemetry.applyTuningValues(this)));
     // Report as YAGSL bc this will become apart of YAGSL in 2027...s
     HAL.report(kResourceType_RobotDrive, kRobotDriveSwerve_YAGSL);
   }
@@ -532,9 +530,8 @@ public class SwerveDrive {
     return new ChassisSpeeds(
         translationDifference.getMeasureX().per(Second).times(translationScalar),
         translationDifference.getMeasureY().per(Second).times(translationScalar),
-        RadiansPerSecond.of(rotationPID.calculate(currentPose.getRotation().getRadians(),
-                                                  targetPose.getRotation().getRadians()))
-    );
+        RadiansPerSecond.of(rotationPID.calculate(
+            currentPose.getRotation().getRadians(), targetPose.getRotation().getRadians())));
   }
 
   /**
@@ -628,14 +625,11 @@ public class SwerveDrive {
       m_simTimer.start();
     }
     Arrays.stream(m_modules).forEach(SwerveModule::simIterate);
-    ChassisSpeeds desired = m_kinematics.toChassisSpeeds(m_desiredModuleStates);
-
     var dt = m_simTimer.get();
-    Twist2d twist = new Twist2d(desired.vxMetersPerSecond * dt, desired.vyMetersPerSecond * dt,
-        desired.omegaRadiansPerSecond * dt);
+    ChassisSpeeds desired = m_kinematics.toChassisSpeeds(m_desiredModuleStates);
+    Twist2d twist = new Twist2d(desired.vxMetersPerSecond * dt, desired.vyMetersPerSecond * dt, desired.omegaRadiansPerSecond * dt);
     m_simPose = m_simPose.exp(twist);
-    m_simGyroAngle = m_simGyroAngle.plus(
-        Radians.of(m_kinematics.toChassisSpeeds(getModuleStates()).omegaRadiansPerSecond * dt));
+    m_simGyroAngle = m_simPose.getRotation().getMeasure();
     m_simTimer.reset();
   }
 

--- a/yams/java/yams/motorcontrollers/SimSupplier.java
+++ b/yams/java/yams/motorcontrollers/SimSupplier.java
@@ -29,8 +29,8 @@ import edu.wpi.first.units.measure.Voltage;
  *
  * <h2>How to use</h2>
  * <p>
- * Create a concrete {@code SimSupplier} (e.g. {@link yams.motorcontrollers.simulation.ArmSimSupplier}
- * or {@link yams.motorcontrollers.simulation.DCMotorSimSupplier}) and pass it to
+ * Create a concrete {@code SimSupplier} (e.g. {@link yams.motorcontrollers.simulation.ArmSimSupplier} or {@link
+  yams.motorcontrollers.simulation.DCMotorSimSupplier}) and pass it to
  * {@code SmartMotorControllerConfig} via {@code withSimSupplier()}:
  * </p>
  * <pre>{@code
@@ -57,8 +57,7 @@ import edu.wpi.first.units.measure.Voltage;
  * ({@link #feedUpdateSim()}/{@link #starveUpdateSim()}).
  * </p>
  */
-public interface SimSupplier
-{
+public interface SimSupplier {
   /**
    * Update the sim state.
    */
@@ -170,11 +169,17 @@ public interface SimSupplier
   AngularVelocity getRotorVelocity();
 
   /**
-   * Get the current draw of from the sim.
+   * Get the stator current draw of from the sim.
    *
-   * @return Current draw.
+   * @return stator current draw.
    */
-  Current getCurrentDraw();
+  Current getStatorCurrent();
+
+  /**
+   * Get the supply current draw of the motor controller.
+   * @return supply current draw.
+   */
+  Current getSupplyCurrent();
 
   /**
    * Get the rotor acceleration.

--- a/yams/java/yams/motorcontrollers/SmartMotorController.java
+++ b/yams/java/yams/motorcontrollers/SmartMotorController.java
@@ -56,6 +56,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import yams.exceptions.SmartMotorControllerConfigurationException;
 import yams.gearing.MechanismGearing;
 import yams.math.LQRController;
+import yams.motorcontrollers.simulation.BatterySim;
 import yams.motorcontrollers.SmartMotorControllerConfig.ControlMode;
 import yams.motorcontrollers.SmartMotorControllerConfig.MotorMode;
 import yams.motorcontrollers.SmartMotorControllerConfig.TelemetryVerbosity;
@@ -1278,6 +1279,7 @@ public abstract class SmartMotorController
     {
       m_rioClosedLoopAlert.set(false);
     }
+    BatterySim.removeCurrent(m_batterySimUUID);
     telemetry.close();
   }
 

--- a/yams/java/yams/motorcontrollers/SmartMotorControllerConfig.java
+++ b/yams/java/yams/motorcontrollers/SmartMotorControllerConfig.java
@@ -10,6 +10,7 @@ import static edu.wpi.first.units.Units.Kilograms;
 import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.MetersPerSecond;
 import static edu.wpi.first.units.Units.MetersPerSecondPerSecond;
+import static edu.wpi.first.units.Units.Milliseconds;
 import static edu.wpi.first.units.Units.RadiansPerSecond;
 import static edu.wpi.first.units.Units.RadiansPerSecondPerSecond;
 import static edu.wpi.first.units.Units.Rotations;
@@ -204,6 +205,13 @@ public class SmartMotorControllerConfig {
    */
   private Optional<Time> controlPeriod = Optional.empty();
   /**
+   * Simulation loop period, the rate at which {@link SmartMotorController#simIterate()} steps the
+   * simulated physics forward. This is independent of {@link #controlPeriod} — a robot can run its
+   * periodic loop at 20ms while stepping simulation physics at 5ms, for example. Defaults to 20ms
+   * if not configured.
+   */
+  private Optional<Time> simulationPeriod = Optional.empty();
+  /**
    * Open loop ramp rate, amount of time to go from 0 to 100 speed..
    */
   private Optional<Time> openLoopRampRate = Optional.empty();
@@ -373,6 +381,7 @@ public class SmartMotorControllerConfig {
     this.externalEncoderGearing = cfg.externalEncoderGearing;
     this.mechanismCircumference = cfg.mechanismCircumference;
     this.controlPeriod = cfg.controlPeriod;
+    this.simulationPeriod = cfg.simulationPeriod;
     this.openLoopRampRate = cfg.openLoopRampRate;
     this.closeLoopRampRate = cfg.closeLoopRampRate;
     this.statorStallCurrentLimit = cfg.statorStallCurrentLimit;
@@ -1217,6 +1226,31 @@ public class SmartMotorControllerConfig {
   public SmartMotorControllerConfig withClosedLoopControlPeriod(Frequency time) {
     controlPeriod = Optional.of(time.asPeriod());
     return this;
+  }
+
+  /**
+   * Set the simulation loop period — the rate at which {@link SmartMotorController#simIterate()}
+   * steps the simulated physics forward. Independent of {@link #withClosedLoopControlPeriod(Time)};
+   * a robot can run its periodic loop at 20ms while stepping simulation physics at 5ms, for
+   * example. Defaults to 20ms if not set.
+   *
+   * @param time Simulation loop period.
+   * @return {@link SmartMotorControllerConfig} for chaining.
+   */
+  public SmartMotorControllerConfig withSimulationPeriod(Time time) {
+    simulationPeriod = Optional.of(time);
+    return this;
+  }
+
+  /**
+   * Get the simulation loop period — the rate at which {@link SmartMotorController#simIterate()}
+   * steps the simulated physics forward. Defaults to 20ms if not set via
+   * {@link #withSimulationPeriod(Time)}.
+   *
+   * @return Simulation loop period.
+   */
+  public Time getSimulationPeriod() {
+    return simulationPeriod.orElse(Milliseconds.of(20));
   }
 
   /**

--- a/yams/java/yams/motorcontrollers/local/SparkWrapper.java
+++ b/yams/java/yams/motorcontrollers/local/SparkWrapper.java
@@ -302,7 +302,7 @@ public class SparkWrapper extends SmartMotorController
       {
         m_simSupplier.get().updateSimState();
         m_simSupplier.get().starveUpdateSim();
-        BatterySim.calculateVoltage(m_batterySimUUID, m_simSupplier.get().getCurrentDraw());
+        BatterySim.calculateVoltage(m_batterySimUUID, m_simSupplier.get().getSupplyCurrent());
       }
       Time controlLoop = m_config.getClosedLoopControlPeriod().orElse(Milliseconds.of(20));
       m_simSupplier.ifPresent(mSimSupplier -> {
@@ -841,7 +841,7 @@ public class SparkWrapper extends SmartMotorController
   @Override
   public Current getStatorCurrent()
   {
-    return m_simSupplier.isPresent() ? m_simSupplier.get().getCurrentDraw() : Amps.of(m_spark.getOutputCurrent());
+    return m_simSupplier.isPresent() ? m_simSupplier.get().getStatorCurrent() : Amps.of(m_spark.getOutputCurrent());
   }
 
   @Override

--- a/yams/java/yams/motorcontrollers/local/SparkWrapper.java
+++ b/yams/java/yams/motorcontrollers/local/SparkWrapper.java
@@ -304,18 +304,18 @@ public class SparkWrapper extends SmartMotorController
         m_simSupplier.get().starveUpdateSim();
         BatterySim.calculateVoltage(m_batterySimUUID, m_simSupplier.get().getSupplyCurrent());
       }
-      Time controlLoop = m_config.getClosedLoopControlPeriod().orElse(Milliseconds.of(20));
+      Time simLoop = m_config.getSimulationPeriod();
       m_simSupplier.ifPresent(mSimSupplier -> {
         sparkSim.ifPresent(sim -> sim.iterate(mSimSupplier.getMechanismVelocity().in(RotationsPerSecond),
                                               mSimSupplier.getMechanismSupplyVoltage().in(Volts),
-                                              controlLoop.in(Second)));
+                                              simLoop.in(Second)));
         sparkRelativeEncoderSim.ifPresent(sim -> sim.iterate(mSimSupplier.getMechanismVelocity()
                                                                          .in(RotationsPerSecond),
-                                                             controlLoop.in(Seconds)));
+                                                             simLoop.in(Seconds)));
         m_sparkAbsoluteEncoderSim.ifPresent(absoluteEncoderSim ->
                                                 absoluteEncoderSim.iterate(mSimSupplier.getMechanismVelocity()
                                                                                        .in(RotationsPerSecond),
-                                                                           controlLoop.in(Seconds)));
+                                                                           simLoop.in(Seconds)));
       });
       // TODO: Uncomment after the 2026 season
 //      m_looseFollowers.ifPresent(smcs -> {for(var f : smcs){f.simIterate();}});

--- a/yams/java/yams/motorcontrollers/remote/TalonFXSWrapper.java
+++ b/yams/java/yams/motorcontrollers/remote/TalonFXSWrapper.java
@@ -62,6 +62,7 @@ import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.math.trajectory.TrapezoidProfile.Constraints;
 import edu.wpi.first.units.AngularAccelerationUnit;
 import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.units.measure.Frequency;
 import edu.wpi.first.units.measure.AngularAcceleration;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Current;
@@ -738,6 +739,11 @@ public class TalonFXSWrapper extends SmartMotorController
     this.m_config = config;
     m_lqr = config.getLQRClosedLoopController();
     this.m_looseFollowers = config.getLooselyCoupledFollowers();
+
+    // Sim periodic
+    if(RobotBase.isSimulation() && !m_config.getSimulationPeriod().isEquivalent(Milliseconds.of(20)))
+      setUpdateFrequency(m_config.getSimulationPeriod().asFrequency());
+
     // Closed loop controllers.
     for (var closedLoopControlSlot : ClosedLoopControllerSlot.values())
     {
@@ -1203,6 +1209,24 @@ public class TalonFXSWrapper extends SmartMotorController
     config.validateExternalEncoderOptions();
 
     return forceConfigApply().isOK();
+  }
+
+  /**
+   * Set the update frequency of the {@link StatusSignal}s used by this {@link SmartMotorController}
+   * @param freq {@link Frequency} to use.
+   */
+  public void setUpdateFrequency(Frequency freq)
+  {
+    m_mechanismPosition.setUpdateFrequency(freq);
+    m_mechanismVelocity.setUpdateFrequency(freq);
+    m_mechanismAcceleration.setUpdateFrequency(freq);
+    m_dutyCycle.setUpdateFrequency(freq);
+    m_statorCurrent.setUpdateFrequency(freq);
+    m_supplyCurrent.setUpdateFrequency(freq);
+    m_outputVoltage.setUpdateFrequency(freq);
+    m_rotorPosition.setUpdateFrequency(freq);
+    m_rotorVelocity.setUpdateFrequency(freq);
+    m_deviceTemperature.setUpdateFrequency(freq);
   }
 
   @Override

--- a/yams/java/yams/motorcontrollers/remote/TalonFXSWrapper.java
+++ b/yams/java/yams/motorcontrollers/remote/TalonFXSWrapper.java
@@ -437,7 +437,7 @@ public class TalonFXSWrapper extends SmartMotorController
         simSupplier.setMechanismStatorVoltage(motorVoltage); // dcmotorSim.setInputVoltage(motorVoltage)
         simSupplier.updateSimState(); // dcmotorSim.update(0.020)
         simSupplier.starveUpdateSim(); // clear update once atomic
-        BatterySim.calculateVoltage(m_batterySimUUID, simSupplier.getCurrentDraw());
+        BatterySim.calculateVoltage(m_batterySimUUID, simSupplier.getSupplyCurrent());
       });
 
       // apply the new rotor position and velocity to the TalonFX;

--- a/yams/java/yams/motorcontrollers/remote/TalonFXWrapper.java
+++ b/yams/java/yams/motorcontrollers/remote/TalonFXWrapper.java
@@ -63,7 +63,7 @@ import edu.wpi.first.units.measure.AngularAcceleration;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.units.measure.Distance;
-import edu.wpi.first.units.measure.LinearAcceleration;
+import edu.wpi.first.units.measure.Frequency;import edu.wpi.first.units.measure.LinearAcceleration;
 import edu.wpi.first.units.measure.LinearVelocity;
 import edu.wpi.first.units.measure.Temperature;
 import edu.wpi.first.units.measure.Time;
@@ -710,6 +710,11 @@ public class TalonFXWrapper extends SmartMotorController
     this.m_config = config;
     this.m_looseFollowers = config.getLooselyCoupledFollowers();
     m_lqr = config.getLQRClosedLoopController();
+
+    // Sim periodic
+    if(RobotBase.isSimulation() && !m_config.getSimulationPeriod().isEquivalent(Milliseconds.of(20)))
+      setUpdateFrequency(m_config.getSimulationPeriod().asFrequency());
+
     // Closed loop controllers.
     for (var closedLoopControlSlot : ClosedLoopControllerSlot.values())
     {
@@ -1188,6 +1193,23 @@ public class TalonFXWrapper extends SmartMotorController
     return forceConfigApply().isOK();
   }
 
+  /**
+   * Set the update frequency of the {@link StatusSignal}s used by this {@link SmartMotorController}
+   * @param freq {@link Frequency} to use.
+   */
+  public void setUpdateFrequency(Frequency freq)
+  {
+    m_mechanismPosition.setUpdateFrequency(freq);
+    m_mechanismVelocity.setUpdateFrequency(freq);
+    m_mechanismAcceleration.setUpdateFrequency(freq);
+    m_dutyCycle.setUpdateFrequency(freq);
+    m_statorCurrent.setUpdateFrequency(freq);
+    m_supplyCurrent.setUpdateFrequency(freq);
+    m_outputVoltage.setUpdateFrequency(freq);
+    m_rotorPosition.setUpdateFrequency(freq);
+    m_rotorVelocity.setUpdateFrequency(freq);
+    m_deviceTemperature.setUpdateFrequency(freq);
+  }
   @Override
   public Optional<Current> getSupplyCurrent()
   {

--- a/yams/java/yams/motorcontrollers/remote/TalonFXWrapper.java
+++ b/yams/java/yams/motorcontrollers/remote/TalonFXWrapper.java
@@ -402,7 +402,7 @@ public class TalonFXWrapper extends SmartMotorController
         simSupplier.setMechanismStatorVoltage(motorVoltage); // dcmotorSim.setInputVoltage(motorVoltage)
         simSupplier.updateSimState(); // dcmotorSim.update(0.020)
         simSupplier.starveUpdateSim(); // clear update once atomic
-        BatterySim.calculateVoltage(m_batterySimUUID, simSupplier.getCurrentDraw());
+        BatterySim.calculateVoltage(m_batterySimUUID, simSupplier.getSupplyCurrent());
       });
 
       // apply the new rotor position and velocity to the TalonFX;

--- a/yams/java/yams/motorcontrollers/simulation/ArmSimSupplier.java
+++ b/yams/java/yams/motorcontrollers/simulation/ArmSimSupplier.java
@@ -74,7 +74,7 @@ public class ArmSimSupplier implements SimSupplier {
   private final LinearFilter supplyCurrentFilter;
   private final SingleJointedArmSim sim;
   private final MechanismGearing mechGearing;
-  private final Time period;
+  private final Time simPeriod;
   private final DCMotor motor;
   private final UUID uuid;
 
@@ -89,10 +89,11 @@ public class ArmSimSupplier implements SimSupplier {
     sim = simulation;
     motorDutyCycleSupplier = smartMotorController::getDutyCycle;
     mechGearing = config.getGearing();
-    period = config.getClosedLoopControlPeriod().orElse(Milliseconds.of(20));
+    simPeriod = config.getSimulationPeriod();
     motor = smartMotorController.getDCMotor();
-    accel = new DerivativeTimeFilter(period);
-    supplyCurrentFilter = LinearFilter.singlePoleIIR(Hertz.of(1000).asPeriod().in(Seconds), period.in(Seconds));
+    accel = new DerivativeTimeFilter(simPeriod);
+    // Based off comment from https://github.com/wpilibsuite/allwpilib/issues/8691
+    supplyCurrentFilter = LinearFilter.singlePoleIIR(Milliseconds.of(100).in(Seconds), simPeriod.in(Seconds));
     uuid = smartMotorController.m_batterySimUUID;
   }
 
@@ -104,7 +105,7 @@ public class ArmSimSupplier implements SimSupplier {
     }
     if (!simUpdated) {
       starveInput();
-      sim.update(period.in(Seconds));
+      sim.update(simPeriod.in(Seconds));
       try {
         // Thread.sleep(1);
       } catch (Exception e) {

--- a/yams/java/yams/motorcontrollers/simulation/ArmSimSupplier.java
+++ b/yams/java/yams/motorcontrollers/simulation/ArmSimSupplier.java
@@ -4,6 +4,7 @@
 package yams.motorcontrollers.simulation;
 
 import static edu.wpi.first.units.Units.Amps;
+import static edu.wpi.first.units.Units.Hertz;
 import static edu.wpi.first.units.Units.Microsecond;
 import static edu.wpi.first.units.Units.Milliseconds;
 import static edu.wpi.first.units.Units.Radians;
@@ -12,6 +13,7 @@ import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Seconds;
 import static edu.wpi.first.units.Units.Volts;
 
+import edu.wpi.first.math.filter.LinearFilter;
 import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularAcceleration;
@@ -64,18 +66,17 @@ import yams.motorcontrollers.SmartMotorController;
  * motor.getConfig().withSimSupplier(sim);
  * }</pre>
  */
-public class ArmSimSupplier implements SimSupplier
-{
-  private       boolean             inputFed   = false;
-  private       boolean             simUpdated = false;
-  private final Supplier<Double>    motorDutyCycleSupplier;
+public class ArmSimSupplier implements SimSupplier {
+  private boolean inputFed = false;
+  private boolean simUpdated = false;
+  private final Supplier<Double> motorDutyCycleSupplier;
   private final DerivativeTimeFilter accel;
+  private final LinearFilter supplyCurrentFilter;
   private final SingleJointedArmSim sim;
-  private final MechanismGearing    mechGearing;
-  private final Time                period;
-  private final DCMotor             motor;
-  private final UUID                uuid;
-
+  private final MechanismGearing mechGearing;
+  private final Time period;
+  private final DCMotor motor;
+  private final UUID uuid;
 
   /**
    * Construct the ArmSim supplier
@@ -83,8 +84,7 @@ public class ArmSimSupplier implements SimSupplier
    * @param simulation           Simulatoin instance
    * @param smartMotorController SMC for the ArmSim..
    */
-  public ArmSimSupplier(SingleJointedArmSim simulation, SmartMotorController smartMotorController)
-  {
+  public ArmSimSupplier(SingleJointedArmSim simulation, SmartMotorController smartMotorController) {
     var config = smartMotorController.getConfig();
     sim = simulation;
     motorDutyCycleSupplier = smartMotorController::getDutyCycle;
@@ -92,141 +92,127 @@ public class ArmSimSupplier implements SimSupplier
     period = config.getClosedLoopControlPeriod().orElse(Milliseconds.of(20));
     motor = smartMotorController.getDCMotor();
     accel = new DerivativeTimeFilter(period);
+    supplyCurrentFilter = LinearFilter.singlePoleIIR(Hertz.of(1000).asPeriod().in(Seconds), period.in(Seconds));
     uuid = smartMotorController.m_batterySimUUID;
   }
 
   @Override
-  public void updateSimState()
-  {
-    if (!isInputFed())
-    {
+  public void updateSimState() {
+    if (!isInputFed()) {
       sim.setInputVoltage(motorDutyCycleSupplier.get() * RoboRioSim.getVInVoltage());
       RoboRioSim.setVInVoltage(BatterySim.calculateVoltage(uuid, sim.getCurrentDrawAmps()));
     }
-    if (!simUpdated)
-    {
+    if (!simUpdated) {
       starveInput();
       sim.update(period.in(Seconds));
-      try
-      {
-        //Thread.sleep(1);
-      } catch (Exception e)
-      {
+      try {
+        // Thread.sleep(1);
+      } catch (Exception e) {
       }
       feedUpdateSim();
     }
-
   }
 
   @Override
-  public boolean getUpdatedSim()
-  {
+  public boolean getUpdatedSim() {
     return simUpdated;
   }
 
   @Override
-  public void feedUpdateSim()
-  {
+  public void feedUpdateSim() {
     simUpdated = true;
   }
 
   @Override
-  public void starveUpdateSim()
-  {
+  public void starveUpdateSim() {
     simUpdated = false;
   }
 
   @Override
-  public boolean isInputFed()
-  {
+  public boolean isInputFed() {
     return inputFed;
   }
 
   @Override
-  public void feedInput()
-  {
+  public void feedInput() {
     inputFed = true;
   }
 
   @Override
-  public void starveInput()
-  {
+  public void starveInput() {
     inputFed = false;
   }
 
   @Override
-  public void setMechanismStatorDutyCycle(double dutyCycle)
-  {
+  public void setMechanismStatorDutyCycle(double dutyCycle) {
     feedInput();
     sim.setInputVoltage(dutyCycle * getMechanismSupplyVoltage().in(Volts));
   }
 
   @Override
-  public Voltage getMechanismSupplyVoltage()
-  {
+  public Voltage getMechanismSupplyVoltage() {
     return Volts.of(RoboRioSim.getVInVoltage());
   }
 
   @Override
-  public Voltage getMechanismStatorVoltage()
-  {
-    return Volts.of(motor.getVoltage(motor.getTorque(sim.getCurrentDrawAmps()),
-                                     sim.getVelocityRadPerSec()));
+  public Voltage getMechanismStatorVoltage() {
+    return Volts.of(
+        motor.getVoltage(motor.getTorque(sim.getCurrentDrawAmps()), sim.getVelocityRadPerSec()));
   }
 
   @Override
-  public void setMechanismStatorVoltage(Voltage volts)
-  {
+  public void setMechanismStatorVoltage(Voltage volts) {
     feedInput();
     sim.setInputVoltage(volts.in(Volts));
   }
 
   @Override
-  public Angle getMechanismPosition()
-  {
+  public Angle getMechanismPosition() {
     return Radians.of(sim.getAngleRads());
   }
 
   @Override
-  public void setMechanismPosition(Angle position)
-  {
+  public void setMechanismPosition(Angle position) {
     sim.setState(position.in(Radians),
-                 sim.getVelocityRadPerSec());//.times(config.getGearing().getMechanismToRotorRatio()).in(Radians));
+        sim.getVelocityRadPerSec()); //.times(config.getGearing().getMechanismToRotorRatio()).in(Radians));
   }
 
   @Override
-  public Angle getRotorPosition()
-  {
+  public Angle getRotorPosition() {
     return getMechanismPosition().times(mechGearing.getMechanismToRotorRatio());
   }
 
   @Override
-  public AngularVelocity getMechanismVelocity()
-  {
+  public AngularVelocity getMechanismVelocity() {
     return RadiansPerSecond.of(sim.getVelocityRadPerSec());
   }
 
   @Override
-  public void setMechanismVelocity(AngularVelocity velocity)
-  {
+  public void setMechanismVelocity(AngularVelocity velocity) {
     sim.setState(sim.getAngleRads(), velocity.in(RadiansPerSecond));
   }
 
   @Override
-  public AngularVelocity getRotorVelocity()
-  {
+  public AngularVelocity getRotorVelocity() {
     return getMechanismVelocity().times(mechGearing.getMechanismToRotorRatio());
   }
 
   @Override
-  public Current getCurrentDraw()
-  {
+  public Current getStatorCurrent() {
     return Amps.of(sim.getCurrentDrawAmps());
+  }
+  @Override
+  public Current getSupplyCurrent() {
+    // For a BLDC driven by a switching converter, power is conserved across the duty-cycle
+    // transformation: supplyVoltage * supplyCurrent = statorVoltage * statorCurrent, and
+    // statorVoltage = dutyCycle * supplyVoltage, so supplyCurrent = dutyCycle * statorCurrent.
+    double dutyCycle = motorDutyCycleSupplier.get();
+    return Amps.of(supplyCurrentFilter.calculate(dutyCycle * sim.getCurrentDrawAmps()));
   }
 
   @Override
-  public AngularAcceleration getRotorAcceleration()
-  {
-    return RotationsPerSecond.per(Microsecond).of(accel.derivative(getRotorVelocity().in(RotationsPerSecond)));
+  public AngularAcceleration getRotorAcceleration() {
+    return RotationsPerSecond.per(Microsecond)
+        .of(accel.derivative(getRotorVelocity().in(RotationsPerSecond)));
   }
 }

--- a/yams/java/yams/motorcontrollers/simulation/ArmSimSupplier.java
+++ b/yams/java/yams/motorcontrollers/simulation/ArmSimSupplier.java
@@ -100,7 +100,7 @@ public class ArmSimSupplier implements SimSupplier {
   public void updateSimState() {
     if (!isInputFed()) {
       sim.setInputVoltage(motorDutyCycleSupplier.get() * RoboRioSim.getVInVoltage());
-      RoboRioSim.setVInVoltage(BatterySim.calculateVoltage(uuid, sim.getCurrentDrawAmps()));
+      RoboRioSim.setVInVoltage(BatterySim.calculateVoltage(uuid, getSupplyCurrent()));
     }
     if (!simUpdated) {
       starveInput();

--- a/yams/java/yams/motorcontrollers/simulation/BatterySim.java
+++ b/yams/java/yams/motorcontrollers/simulation/BatterySim.java
@@ -147,6 +147,17 @@ public class BatterySim {
   }
 
   /**
+   * Stop counting the given simulation's current draw towards the shared battery load, e.g. once
+   * its {@link yams.motorcontrollers.SmartMotorController} has been closed. Without this, a closed
+   * simulation's last-known current draw would linger in {@link #currents} indefinitely.
+   *
+   * @param id {@link UUID} of the simulation to remove.
+   */
+  public static void removeCurrent(UUID id) {
+    currents.remove(id);
+  }
+
+  /**
    * Get the simulated state of charge of the battery, from 0 (empty) to 1 (full).
    *
    * @return State of charge of the battery.

--- a/yams/java/yams/motorcontrollers/simulation/DCMotorSimSupplier.java
+++ b/yams/java/yams/motorcontrollers/simulation/DCMotorSimSupplier.java
@@ -4,12 +4,15 @@
 package yams.motorcontrollers.simulation;
 
 import static edu.wpi.first.units.Units.Amps;
+import static edu.wpi.first.units.Units.Hertz;
+import static edu.wpi.first.units.Units.Millihertz;
 import static edu.wpi.first.units.Units.Milliseconds;
 import static edu.wpi.first.units.Units.Radians;
 import static edu.wpi.first.units.Units.RadiansPerSecond;
 import static edu.wpi.first.units.Units.Seconds;
 import static edu.wpi.first.units.Units.Volts;
 
+import edu.wpi.first.math.filter.LinearFilter;
 import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularAcceleration;
@@ -62,17 +65,16 @@ import yams.motorcontrollers.SmartMotorController;
  * motor.getConfig().withSimSupplier(sim);
  * }</pre>
  */
-public class DCMotorSimSupplier implements SimSupplier
-{
-  private boolean          inputFed   = false;
-  private       boolean          simUpdated = false;
+public class DCMotorSimSupplier implements SimSupplier {
+  private boolean inputFed = false;
+  private boolean simUpdated = false;
   private final Supplier<Double> motorDutyCycleSupplier;
-  private final DCMotorSim       sim;
+  private final LinearFilter supplyCurrentFilter;
+  private final DCMotorSim sim;
   private final MechanismGearing mechGearing;
-  private final Time             period;
-  private final DCMotor          motor;
-  private final UUID             uuid;
-
+  private final Time period;
+  private final DCMotor motor;
+  private final UUID uuid;
 
   /**
    * Construct the DCMotorSim supplier
@@ -80,149 +82,134 @@ public class DCMotorSimSupplier implements SimSupplier
    * @param simulation           Simulatoin instance
    * @param smartMotorController SMC for the DCMotorSim..
    */
-  public DCMotorSimSupplier(DCMotorSim simulation, SmartMotorController smartMotorController)
-  {
+  public DCMotorSimSupplier(DCMotorSim simulation, SmartMotorController smartMotorController) {
     var config = smartMotorController.getConfig();
     sim = simulation;
     motorDutyCycleSupplier = smartMotorController::getDutyCycle;
     mechGearing = config.getGearing();
     period = config.getClosedLoopControlPeriod().orElse(Milliseconds.of(20));
     motor = smartMotorController.getDCMotor();
+    supplyCurrentFilter = LinearFilter.singlePoleIIR(Millihertz.of(1000).in(Hertz), period.in(Seconds));
     uuid = smartMotorController.m_batterySimUUID;
   }
 
   @Override
-  public void updateSimState()
-  {
-    if (!isInputFed())
-    {
-      sim.setInputVoltage(motorDutyCycleSupplier.get() * RoboRioSim.getVInVoltage());
+  public void updateSimState() {
+    if (!isInputFed()) {
+      sim.setInputVoltage(
+          motorDutyCycleSupplier.get() * RoboRioSim.getVInVoltage()); // Supply voltage
       RoboRioSim.setVInVoltage(BatterySim.calculateVoltage(uuid, sim.getCurrentDrawAmps()));
     }
-    if (!simUpdated)
-    {
+    if (!simUpdated) {
       starveInput();
       sim.update(period.in(Seconds));
-      try
-      {
-        //Thread.sleep(1);
-      } catch (Exception e)
-      {
+      try {
+        // Thread.sleep(1);
+      } catch (Exception e) {
       }
       feedUpdateSim();
     }
-
   }
 
   @Override
-  public boolean getUpdatedSim()
-  {
+  public boolean getUpdatedSim() {
     return simUpdated;
   }
 
   @Override
-  public void feedUpdateSim()
-  {
+  public void feedUpdateSim() {
     simUpdated = true;
   }
 
   @Override
-  public void starveUpdateSim()
-  {
+  public void starveUpdateSim() {
     simUpdated = false;
   }
 
   @Override
-  public boolean isInputFed()
-  {
+  public boolean isInputFed() {
     return inputFed;
   }
 
   @Override
-  public void feedInput()
-  {
+  public void feedInput() {
     inputFed = true;
   }
 
   @Override
-  public void starveInput()
-  {
+  public void starveInput() {
     inputFed = false;
   }
 
   @Override
-  public void setMechanismStatorDutyCycle(double dutyCycle)
-  {
+  public void setMechanismStatorDutyCycle(double dutyCycle) {
     feedInput();
     sim.setInputVoltage(dutyCycle * getMechanismSupplyVoltage().in(Volts));
   }
 
   @Override
-  public Voltage getMechanismSupplyVoltage()
-  {
+  public Voltage getMechanismSupplyVoltage() {
     return Volts.of(RoboRioSim.getVInVoltage());
   }
 
   @Override
-  public Voltage getMechanismStatorVoltage()
-  {
-    return Volts.of(motor.getVoltage(sim.getTorqueNewtonMeters(),
-                                     sim.getAngularVelocityRadPerSec()));
+  public Voltage getMechanismStatorVoltage() {
+    return Volts.of(
+        motor.getVoltage(sim.getTorqueNewtonMeters(), sim.getAngularVelocityRadPerSec()));
   }
 
   @Override
-  public void setMechanismStatorVoltage(Voltage volts)
-  {
+  public void setMechanismStatorVoltage(Voltage volts) {
     feedInput();
     sim.setInputVoltage(volts.in(Volts));
   }
 
   @Override
-  public Angle getMechanismPosition()
-  {
+  public Angle getMechanismPosition() {
     return sim.getAngularPosition();
   }
 
   @Override
-  public void setMechanismPosition(Angle position)
-  {
-    sim
-        .setAngle(position.in(Radians));//.times(config.getGearing().getMechanismToRotorRatio()).in(Radians));
+  public void setMechanismPosition(Angle position) {
+    sim.setAngle(position.in(
+        Radians)); //.times(config.getGearing().getMechanismToRotorRatio()).in(Radians));
   }
 
   @Override
-  public Angle getRotorPosition()
-  {
+  public Angle getRotorPosition() {
     return getMechanismPosition().times(mechGearing.getMechanismToRotorRatio());
   }
 
   @Override
-  public AngularVelocity getMechanismVelocity()
-  {
+  public AngularVelocity getMechanismVelocity() {
     return sim.getAngularVelocity();
   }
 
   @Override
-  public void setMechanismVelocity(AngularVelocity velocity)
-  {
+  public void setMechanismVelocity(AngularVelocity velocity) {
     sim.setAngularVelocity(velocity.in(RadiansPerSecond));
   }
 
   @Override
-  public AngularVelocity getRotorVelocity()
-  {
+  public AngularVelocity getRotorVelocity() {
     return getMechanismVelocity().times(mechGearing.getMechanismToRotorRatio());
   }
 
   @Override
-  public Current getCurrentDraw()
-  {
+  public Current getStatorCurrent() {
     return Amps.of(sim.getCurrentDrawAmps());
+  }
+  @Override
+  public Current getSupplyCurrent() {
+    // For a BLDC driven by a switching converter, power is conserved across the duty-cycle
+    // transformation: supplyVoltage * supplyCurrent = statorVoltage * statorCurrent, and
+    // statorVoltage = dutyCycle * supplyVoltage, so supplyCurrent = dutyCycle * statorCurrent.
+    double dutyCycle = motorDutyCycleSupplier.get();
+    return Amps.of(supplyCurrentFilter.calculate(dutyCycle * sim.getCurrentDrawAmps()));
   }
 
   @Override
-  public AngularAcceleration getRotorAcceleration()
-  {
+  public AngularAcceleration getRotorAcceleration() {
     return sim.getAngularAcceleration();
   }
 }

--- a/yams/java/yams/motorcontrollers/simulation/DCMotorSimSupplier.java
+++ b/yams/java/yams/motorcontrollers/simulation/DCMotorSimSupplier.java
@@ -98,7 +98,7 @@ public class DCMotorSimSupplier implements SimSupplier {
     if (!isInputFed()) {
       sim.setInputVoltage(
           motorDutyCycleSupplier.get() * RoboRioSim.getVInVoltage()); // Supply voltage
-      RoboRioSim.setVInVoltage(BatterySim.calculateVoltage(uuid, sim.getCurrentDrawAmps()));
+      RoboRioSim.setVInVoltage(BatterySim.calculateVoltage(uuid, getSupplyCurrent()));
     }
     if (!simUpdated) {
       starveInput();

--- a/yams/java/yams/motorcontrollers/simulation/DCMotorSimSupplier.java
+++ b/yams/java/yams/motorcontrollers/simulation/DCMotorSimSupplier.java
@@ -6,8 +6,7 @@ package yams.motorcontrollers.simulation;
 import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.Hertz;
 import static edu.wpi.first.units.Units.Millihertz;
-import static edu.wpi.first.units.Units.Milliseconds;
-import static edu.wpi.first.units.Units.Radians;
+import static edu.wpi.first.units.Units.Milliseconds;import static edu.wpi.first.units.Units.Radians;
 import static edu.wpi.first.units.Units.RadiansPerSecond;
 import static edu.wpi.first.units.Units.Seconds;
 import static edu.wpi.first.units.Units.Volts;
@@ -72,7 +71,7 @@ public class DCMotorSimSupplier implements SimSupplier {
   private final LinearFilter supplyCurrentFilter;
   private final DCMotorSim sim;
   private final MechanismGearing mechGearing;
-  private final Time period;
+  private final Time simPeriod;
   private final DCMotor motor;
   private final UUID uuid;
 
@@ -87,9 +86,10 @@ public class DCMotorSimSupplier implements SimSupplier {
     sim = simulation;
     motorDutyCycleSupplier = smartMotorController::getDutyCycle;
     mechGearing = config.getGearing();
-    period = config.getClosedLoopControlPeriod().orElse(Milliseconds.of(20));
+    simPeriod = config.getSimulationPeriod();
     motor = smartMotorController.getDCMotor();
-    supplyCurrentFilter = LinearFilter.singlePoleIIR(Millihertz.of(1000).in(Hertz), period.in(Seconds));
+    // Based off comment from https://github.com/wpilibsuite/allwpilib/issues/8691
+    supplyCurrentFilter = LinearFilter.singlePoleIIR(Milliseconds.of(100).in(Seconds), simPeriod.in(Seconds));
     uuid = smartMotorController.m_batterySimUUID;
   }
 
@@ -102,7 +102,7 @@ public class DCMotorSimSupplier implements SimSupplier {
     }
     if (!simUpdated) {
       starveInput();
-      sim.update(period.in(Seconds));
+      sim.update(simPeriod.in(Seconds));
       try {
         // Thread.sleep(1);
       } catch (Exception e) {

--- a/yams/java/yams/motorcontrollers/simulation/ElevatorSimSupplier.java
+++ b/yams/java/yams/motorcontrollers/simulation/ElevatorSimSupplier.java
@@ -4,6 +4,7 @@
 package yams.motorcontrollers.simulation;
 
 import static edu.wpi.first.units.Units.Amps;
+import static edu.wpi.first.units.Units.Hertz;
 import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.MetersPerSecond;
 import static edu.wpi.first.units.Units.Microsecond;
@@ -13,6 +14,7 @@ import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Seconds;
 import static edu.wpi.first.units.Units.Volts;
 
+import edu.wpi.first.math.filter.LinearFilter;
 import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularAcceleration;
@@ -75,6 +77,7 @@ public class ElevatorSimSupplier implements SimSupplier {
   private final Supplier<Double> pos;
   private final Supplier<Double> mps;
   private final DerivativeTimeFilter mpsps;
+  private final LinearFilter supplyCurrentFilter;
   private boolean inputFed = false;
   private boolean simUpdated = false;
 
@@ -95,6 +98,8 @@ public class ElevatorSimSupplier implements SimSupplier {
     mps = sim::getVelocityMetersPerSecond;
     mpsps = new DerivativeTimeFilter(
         pos.get(), config.getClosedLoopControlPeriod().orElse(Milliseconds.of(20)));
+    supplyCurrentFilter = LinearFilter.singlePoleIIR(Hertz.of(1000).asPeriod().in(Seconds),
+                                                     config.getClosedLoopControlPeriod().orElse(Milliseconds.of(20)).in(Seconds));
   }
 
   @Override
@@ -194,8 +199,17 @@ public class ElevatorSimSupplier implements SimSupplier {
   }
 
   @Override
-  public Current getCurrentDraw() {
+  public Current getStatorCurrent() {
     return Amps.of(sim.getCurrentDrawAmps());
+  }
+
+  @Override
+  public Current getSupplyCurrent() {
+    // For a BLDC driven by a switching converter, power is conserved across the duty-cycle
+    // transformation: supplyVoltage * supplyCurrent = statorVoltage * statorCurrent, and
+    // statorVoltage = dutyCycle * supplyVoltage, so supplyCurrent = dutyCycle * statorCurrent.
+    double dutyCycle = motorDutyCycleSupplier.get();
+    return Amps.of(supplyCurrentFilter.calculate(dutyCycle * sim.getCurrentDrawAmps()));
   }
 
   @Override

--- a/yams/java/yams/motorcontrollers/simulation/ElevatorSimSupplier.java
+++ b/yams/java/yams/motorcontrollers/simulation/ElevatorSimSupplier.java
@@ -106,7 +106,7 @@ public class ElevatorSimSupplier implements SimSupplier {
   public void updateSimState() {
     if (!isInputFed()) {
       sim.setInputVoltage(motorDutyCycleSupplier.get() * RoboRioSim.getVInVoltage());
-      RoboRioSim.setVInVoltage(BatterySim.calculateVoltage(uuid, sim.getCurrentDrawAmps()));
+      RoboRioSim.setVInVoltage(BatterySim.calculateVoltage(uuid, getSupplyCurrent()));
     }
     if (!simUpdated) {
       starveInput();

--- a/yams/java/yams/motorcontrollers/simulation/ElevatorSimSupplier.java
+++ b/yams/java/yams/motorcontrollers/simulation/ElevatorSimSupplier.java
@@ -4,11 +4,11 @@
 package yams.motorcontrollers.simulation;
 
 import static edu.wpi.first.units.Units.Amps;
-import static edu.wpi.first.units.Units.Hertz;
 import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.MetersPerSecond;
 import static edu.wpi.first.units.Units.Microsecond;
-import static edu.wpi.first.units.Units.Milliseconds;import static edu.wpi.first.units.Units.RadiansPerSecond;
+import static edu.wpi.first.units.Units.Milliseconds;
+import static edu.wpi.first.units.Units.RadiansPerSecond;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Seconds;
 import static edu.wpi.first.units.Units.Volts;

--- a/yams/java/yams/motorcontrollers/simulation/ElevatorSimSupplier.java
+++ b/yams/java/yams/motorcontrollers/simulation/ElevatorSimSupplier.java
@@ -8,8 +8,7 @@ import static edu.wpi.first.units.Units.Hertz;
 import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.MetersPerSecond;
 import static edu.wpi.first.units.Units.Microsecond;
-import static edu.wpi.first.units.Units.Milliseconds;
-import static edu.wpi.first.units.Units.RadiansPerSecond;
+import static edu.wpi.first.units.Units.Milliseconds;import static edu.wpi.first.units.Units.RadiansPerSecond;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Seconds;
 import static edu.wpi.first.units.Units.Volts;
@@ -20,6 +19,7 @@ import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularAcceleration;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Current;
+import edu.wpi.first.units.measure.Time;
 import edu.wpi.first.units.measure.Voltage;
 import edu.wpi.first.wpilibj.simulation.ElevatorSim;
 import edu.wpi.first.wpilibj.simulation.RoboRioSim;
@@ -78,6 +78,7 @@ public class ElevatorSimSupplier implements SimSupplier {
   private final Supplier<Double> mps;
   private final DerivativeTimeFilter mpsps;
   private final LinearFilter supplyCurrentFilter;
+  private final Time simPeriod;
   private boolean inputFed = false;
   private boolean simUpdated = false;
 
@@ -96,10 +97,10 @@ public class ElevatorSimSupplier implements SimSupplier {
     motorDutyCycleSupplier = smartMotorController::getDutyCycle;
     pos = sim::getPositionMeters;
     mps = sim::getVelocityMetersPerSecond;
-    mpsps = new DerivativeTimeFilter(
-        pos.get(), config.getClosedLoopControlPeriod().orElse(Milliseconds.of(20)));
-    supplyCurrentFilter = LinearFilter.singlePoleIIR(Hertz.of(1000).asPeriod().in(Seconds),
-                                                     config.getClosedLoopControlPeriod().orElse(Milliseconds.of(20)).in(Seconds));
+    simPeriod = config.getSimulationPeriod();
+    mpsps = new DerivativeTimeFilter(pos.get(), simPeriod);
+    // Based off comment from https://github.com/wpilibsuite/allwpilib/issues/8691
+    supplyCurrentFilter = LinearFilter.singlePoleIIR(Milliseconds.of(100).in(Seconds), simPeriod.in(Seconds));
   }
 
   @Override
@@ -110,7 +111,7 @@ public class ElevatorSimSupplier implements SimSupplier {
     }
     if (!simUpdated) {
       starveInput();
-      sim.update(config.getClosedLoopControlPeriod().orElse(Milliseconds.of(20)).in(Seconds));
+      sim.update(simPeriod.in(Seconds));
       feedUpdateSim();
     }
   }


### PR DESCRIPTION
* SwerveDrive SimPosition was double integrated, resulting in a robot relative movement instead of field relative.
* Added SwerveDriveConfig.clone()
* Added automatically derived gyro angular velocity for angular velocity scaling
* Updated BatterySim to have unit tests
* Added getSupplyCurrent and getStatorCurrent to simSupplier
* Added CTRE.setUpdateFrequency
* Set update frequency when its not 20ms.
* Added sim period
* Added sim period tests
